### PR TITLE
Upgrade dependencies, build tooling, and test container images

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,11 +41,11 @@ version = gitVersion()
 group = "demo"
 
 val javaVersion = JavaVersion.VERSION_25
-val nodeVersion = "24.14.1"
+val nodeVersion = "24.18.0"
 val spotbugsToolVersion = "4.9.8"
 val jacocoToolVersion = "0.8.14"
 val pmdToolVersion = "7.23.0"
-val primefacesVersion = "15.0.15"
+val primefacesVersion = "15.0.17"
 val gsonVersion = "2.14.0"
 val seleniumVersion = "4.45.0"
 val asciiDoctorJVersion = "3.0.0"
@@ -57,7 +57,7 @@ val primefacesThemesVersion = "1.1.0"
 val rerunnerJupiterVersion = "2.1.6"
 val caffeineVersion = "3.2.4"
 val postgresqlVersion = "42.7.13"
-val gradleWrapperVersion = "9.5.1"
+val gradleWrapperVersion = "9.6.1"
 val generatedSnippetsDir = layout.buildDirectory.dir("generated-snippets")
 
 

--- a/src/test/java/com/example/extension/DockerExtension.java
+++ b/src/test/java/com/example/extension/DockerExtension.java
@@ -11,7 +11,7 @@ import java.util.concurrent.locks.ReentrantLock;
 @SuppressWarnings("PMD.DoNotUseThreads")
 public class DockerExtension implements Extension {
 
-    private static final PostgreSQLContainer POSTGRES_SQL_CONTAINER = new PostgreSQLContainer("postgres:14");
+    private static final PostgreSQLContainer POSTGRES_SQL_CONTAINER = new PostgreSQLContainer("postgres:17.10");
     private static final Lock LOCK = new ReentrantLock();
 
     public static PostgreSQLContainer getPostgres() {

--- a/src/test/java/com/example/extension/SeleniumExtension.java
+++ b/src/test/java/com/example/extension/SeleniumExtension.java
@@ -42,7 +42,7 @@ public class SeleniumExtension implements BeforeAllCallback, BeforeEachCallback,
 
     public static final DateTimeFormatter DATE_TIME_FILE_NAME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH.mm.ss");
     private static final String SCREENSHOT_PATH = "./build/screenshot/";
-    private static final BrowserWebDriverContainer WEB_DRIVER_CONTAINER = new BrowserWebDriverContainer(DockerImageName.parse("selenium/standalone-chrome"))
+    private static final BrowserWebDriverContainer WEB_DRIVER_CONTAINER = new BrowserWebDriverContainer(DockerImageName.parse("selenium/standalone-chrome:4.45.0"))
             .withRecordingMode(RECORD_ALL, new File(SCREENSHOT_PATH), MP4)
             .withRecordingFileFactory(new DefaultRecordingFileFactory());
     private static final Lock LOCK = new ReentrantLock();


### PR DESCRIPTION
## Summary

Dependency and tooling refresh identified by the `ben-manes.versions` Gradle plugin, `npm outdated`, and a manual audit of Docker image tags (which the automated tools don't cover).

## Changes

| Item | Before | After | Notes |
|---|---|---|---|
| `primefaces` / `primefaces-extensions` | 15.0.15 (declared) | **15.0.17** | joinfaces BOM already forced 15.0.16 by conflict resolution — the explicit pin was stale *and lower* than the effective version |
| Node (build-pinned) | 24.14.1 | **24.18.0** | latest Node 24 LTS |
| `gradleWrapperVersion` | 9.5.1 | **9.6.1** | matched the actual wrapper; previously `./gradlew wrapper` would have **downgraded** it |
| Test container: Postgres | `postgres:14` | **`postgres:17.10`** | major 14 nears EOL (Nov 2026); patch pinned for reproducibility |
| Test container: Selenium | `selenium/standalone-chrome` *(→ `:latest`)* | **`selenium/standalone-chrome:4.45.0`** | was an unpinned floating tag — now reproducible and aligned with the `selenium-java` client |

## Deliberately deferred

- **`selenium-java` stays at 4.45.0** (not 4.46.0): no `selenium/standalone-chrome:4.46.0` image is published yet, so bumping the client would desync it from the Grid version in the image. Kept aligned instead.

## Everything else was already current

Spring Boot 4.1.0, Java 25, Gradle 9.6.1 (wrapper), all Gradle plugins, SpotBugs/JaCoCo/PMD/AsciidoctorJ, Testcontainers 2.0.5, Postgres driver 42.7.13, and all npm packages (react/react-dom 19.2.7, esbuild 0.28.1).

## Verification

Run locally with Docker (v29.6.1):
- `compileTestJava` — Node 24.18.0 download + npm install + esbuild webpack + main/test compile ✅
- `RestIntegrationTest` + `DbMessageSourceTest` — 12 tests against `postgres:17.10` (Liquibase migrations + JPA) ✅
- `SeleniumIntegrationTest` — 8 E2E tests against `standalone-chrome:4.45.0` (real Chrome through the JSF/PrimeFaces UI) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)