### PR TITLE
Integrate measured performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Spring Boot Aplication with Docker
 ```
 The Gradle build runs the frontend bundle step automatically.
 
+Run the fast unit-only test loop without integration or Selenium tests:
+
+```
+./gradlew unitTest
+```
+
 ### frontend assets
 ```
 npm run build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -398,7 +398,8 @@ val webpackWatch = tasks.register<NodeTask>("webpackWatch") {
 
 tasks.wrapper {
     gradleVersion = gradleWrapperVersion
-    distributionType = Wrapper.DistributionType.ALL
+    distributionType = Wrapper.DistributionType.BIN
+    distributionSha256Sum = "9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14"
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -432,5 +432,5 @@ tasks {
     test {
         outputs.dir(generatedSnippetsDir)
     }
-    test.get().finalizedBy(jacocoTestReport)
+    check.get().dependsOn(jacocoTestReport)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.github.gradle.node.task.NodeTask
 import com.github.spotbugs.snom.SpotBugsTask
 import com.palantir.gradle.gitversion.CommonGitOperations
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
@@ -330,7 +331,6 @@ tasks.jacocoTestReport {
 }
 
 tasks.withType<Test> {
-    outputs.dir(generatedSnippetsDir)
     useJUnitPlatform()
     jvmArgs = listOf(
             "-XX:+EnableDynamicAgentLoading",
@@ -348,6 +348,19 @@ tasks.withType<Test> {
         exceptionFormat = TestExceptionFormat.FULL
         showCauses = true
         showStackTraces = true
+    }
+}
+
+val unitTest = tasks.register<Test>("unitTest") {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Runs unit tests without integration or Selenium tests."
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    useJUnitPlatform {
+        excludeTags("integration", "selenium")
+    }
+    extensions.configure<JacocoTaskExtension> {
+        isEnabled = false
     }
 }
 
@@ -416,5 +429,8 @@ tasks {
         }
     }
     bootJar.get().dependsOn(jar, resolveMainClassName)
+    test {
+        outputs.dir(generatedSnippetsDir)
+    }
     test.get().finalizedBy(jacocoTestReport)
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary

Final measured-performance integration for campaign tracker #1112, layered on the pushed foundation from PR #1125.

- #1118 switches the Gradle wrapper to the checksum-pinned binary-only distribution; the claim is limited to cold bootstrap/download/install footprint, not recurring build speed.
- #1115 adds an isolated `unitTest` task while preserving the existing full `test`, `check`, and `build` behavior.
- #1116 removes automatic JaCoCo finalization from focused tests while preserving coverage generation from `check`, `build`, and explicit `jacocoTestReport`.

## Measured evidence

- Wrapper ZIP: 239,601,473 B (`all`) vs 140,682,664 B (`bin`), 41.28% smaller; installed footprint 516,059,164 B vs 156,462,363 B, 69.68% smaller. Controlled bootstrap medians: 87.322s vs 63.376s in the original block and 33.086s vs 13.794s in the interleaved replacement block.
- Full suite: 47 tests. Unit-only manifest: 33 tests. Controlled actual-execution medians: 69.5s full vs 2.7s unit-only.
- Focused-test A/B/B/A medians: 4.819s with automatic JaCoCo vs 3.749s without, saving 1.070s (22.2%). Full normalized JaCoCo counters remain identical.

## Final-head validation

- `clean build --no-build-cache`: passed; 47 tests including PostgreSQL/Testcontainers/Selenium, JaCoCo, Spotless, PMD, SpotBugs, docs, plain/boot archives, and configuration-cache store.
- `cleanUnitTest unitTest --no-build-cache`: passed; exactly 33 tests in 2.7s.
- Focused `LongStringUtilsTest`: exactly 8 tests; no JaCoCo report task; seeded full XML SHA-256 remained unchanged.
- Exact diff audited against foundation `bc7262f1d5ed08aafd7c61ef33df72649c813387` and source commits `a5dae642`, `d275f6f`, and `069f4ae`.

This PR must remain DRAFT. Do not merge or enable auto-merge.

Refs #1112, #1118, #1115, #1116, #1125.