### PR TITLE
Add configurable Selenium execution mode

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,6 +57,7 @@ jobs:
         run: ./gradlew build -PnodeDownload=false
         env:
           HOST_FOR_SELENIUM: "172.17.0.1"
+          SELENIUM_MODE: container
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/README.md
+++ b/README.md
@@ -25,7 +25,20 @@ npm run watch
 ```
 
 ### selenium tests
-to run selenium test where `host.docker.internal` is not set env variable `HOST_FOR_SELENIUM` can be used
+Selenium tests default to locally installed Chrome (resolved by Selenium Manager), which is convenient for Gradle and
+IDE runs. Select the browser explicitly with `selenium.mode=host|container`; a JVM/Gradle property takes precedence over
+the `SELENIUM_MODE` environment variable. CI sets `SELENIUM_MODE=container` explicitly.
+
+Gradle examples:
+
+```
+./gradlew test -Pselenium.mode=host
+./gradlew test -Pselenium.mode=container
+```
+
+For IntelliJ/JUnit, add `-Dselenium.mode=host` or `-Dselenium.mode=container` to the run configuration's VM options, or
+set `SELENIUM_MODE`. Host mode creates screenshots but no MP4 recording. Container mode keeps Testcontainers, screenshots,
+and VNC MP4 recording. When `host.testcontainers.internal` is unavailable in container mode, set `HOST_FOR_SELENIUM`.
 
 ### Docker
 Install Docker.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -331,6 +331,11 @@ tasks.jacocoTestReport {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    providers.gradleProperty("selenium.mode")
+        .orElse(providers.systemProperty("selenium.mode"))
+        .orElse(providers.environmentVariable("SELENIUM_MODE"))
+        .orNull
+        ?.let { systemProperty("selenium.mode", it) }
     jvmArgs = listOf(
             "-XX:+EnableDynamicAgentLoading",
             "--add-opens=java.base/java.lang=ALL-UNNAMED",

--- a/src/test/java/com/example/extension/SeleniumExtension.java
+++ b/src/test/java/com/example/extension/SeleniumExtension.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static java.util.Map.entry;
+import static com.example.util.LockUtils.withLock;
 import static org.testcontainers.containers.VncRecordingContainer.VncRecordingFormat.MP4;
 import static org.testcontainers.selenium.BrowserWebDriverContainer.VncRecordingMode.RECORD_ALL;
 
@@ -37,7 +38,9 @@ import static org.testcontainers.selenium.BrowserWebDriverContainer.VncRecording
         "PMD.DoNotUseThreads",
         "PMD.TooManyMethods",
         "PMD.AvoidUncheckedExceptionsInSignatures",
-        "PMD.NonThreadSafeSingleton"
+        "PMD.AvoidUsingVolatile",
+        "PMD.ExcessiveImports",
+        "PMD.NullAssignment"
 })
 public class SeleniumExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, ParameterResolver {
 
@@ -48,18 +51,19 @@ public class SeleniumExtension implements BeforeAllCallback, BeforeEachCallback,
             .withRecordingMode(RECORD_ALL, new File(SCREENSHOT_PATH), MP4)
             .withRecordingFileFactory(new DefaultRecordingFileFactory());
     private static final ReentrantLock LOCK = new ReentrantLock();
-    private static RemoteWebDriver webDriver;
+    private static volatile RemoteWebDriver webDriver;
 
     private static RemoteWebDriver getWebDriver() {
-        LOCK.lock();
-        try {
-            if (webDriver == null) {
-                webDriver = startWebDriver();
-            }
-            return webDriver;
-        } finally {
-            LOCK.unlock();
+        RemoteWebDriver currentWebDriver = webDriver;
+        if (currentWebDriver == null) {
+            currentWebDriver = withLock(LOCK, () -> {
+                if (webDriver == null) {
+                    webDriver = startWebDriver();
+                }
+                return webDriver;
+            });
         }
+        return currentWebDriver;
     }
 
     private static RemoteWebDriver startWebDriver() {
@@ -133,14 +137,15 @@ public class SeleniumExtension implements BeforeAllCallback, BeforeEachCallback,
     }
 
     private static void quitHostWebDriver() {
-        LOCK.lock();
-        try {
+        withLock(LOCK, () -> {
             if (webDriver != null) {
-                webDriver.quit();
+                try {
+                    webDriver.quit();
+                } finally {
+                    webDriver = null;
+                }
             }
-        } finally {
-            LOCK.unlock();
-        }
+        });
     }
 
     @Override

--- a/src/test/java/com/example/extension/SeleniumExtension.java
+++ b/src/test/java/com/example/extension/SeleniumExtension.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.openqa.selenium.OutputType;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.DefaultRecordingFileFactory;
@@ -25,7 +26,6 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static java.util.Map.entry;
@@ -36,37 +36,44 @@ import static org.testcontainers.selenium.BrowserWebDriverContainer.VncRecording
 @SuppressWarnings({
         "PMD.DoNotUseThreads",
         "PMD.TooManyMethods",
-        "PMD.AvoidUncheckedExceptionsInSignatures"
+        "PMD.AvoidUncheckedExceptionsInSignatures",
+        "PMD.NonThreadSafeSingleton"
 })
 public class SeleniumExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, ParameterResolver {
 
     public static final DateTimeFormatter DATE_TIME_FILE_NAME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH.mm.ss");
     private static final String SCREENSHOT_PATH = "./build/screenshot/";
+    private static final SeleniumMode SELENIUM_MODE = SeleniumMode.current();
     private static final BrowserWebDriverContainer WEB_DRIVER_CONTAINER = new BrowserWebDriverContainer(DockerImageName.parse("selenium/standalone-chrome:4.45.0"))
             .withRecordingMode(RECORD_ALL, new File(SCREENSHOT_PATH), MP4)
             .withRecordingFileFactory(new DefaultRecordingFileFactory());
-    private static final Lock LOCK = new ReentrantLock();
-
+    private static final ReentrantLock LOCK = new ReentrantLock();
     private static RemoteWebDriver webDriver;
 
     private static RemoteWebDriver getWebDriver() {
-        if (!WEB_DRIVER_CONTAINER.isRunning()) {
-            LOCK.lock();
-            try {
-                if (!WEB_DRIVER_CONTAINER.isRunning()) {
-                    log.info("starting selenium docker container");
-                    WEB_DRIVER_CONTAINER.start();
-                    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                        log.info("stopping selenium docker container");
-                        WEB_DRIVER_CONTAINER.stop();
-                    }));
-                    webDriver = new RemoteWebDriver(WEB_DRIVER_CONTAINER.getSeleniumAddress(), initChromeOptions());
-                }
-            } finally {
-                LOCK.unlock();
+        LOCK.lock();
+        try {
+            if (webDriver == null) {
+                webDriver = startWebDriver();
             }
+            return webDriver;
+        } finally {
+            LOCK.unlock();
         }
-        return webDriver;
+    }
+
+    private static RemoteWebDriver startWebDriver() {
+        if (SELENIUM_MODE == SeleniumMode.HOST) {
+            log.info("starting host Chrome through Selenium Manager");
+            return new ChromeDriver(initChromeOptions());
+        }
+        log.info("starting selenium docker container");
+        WEB_DRIVER_CONTAINER.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("stopping selenium docker container");
+            WEB_DRIVER_CONTAINER.stop();
+        }));
+        return new RemoteWebDriver(WEB_DRIVER_CONTAINER.getSeleniumAddress(), initChromeOptions());
     }
 
     private static void createDirForScreenshots() throws IOException {
@@ -118,7 +125,22 @@ public class SeleniumExtension implements BeforeAllCallback, BeforeEachCallback,
 
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
-        WEB_DRIVER_CONTAINER.afterTest(toTestDescription(context), context.getExecutionException());
+        if (SELENIUM_MODE == SeleniumMode.CONTAINER) {
+            WEB_DRIVER_CONTAINER.afterTest(toTestDescription(context), context.getExecutionException());
+        } else {
+            quitHostWebDriver();
+        }
+    }
+
+    private static void quitHostWebDriver() {
+        LOCK.lock();
+        try {
+            if (webDriver != null) {
+                webDriver.quit();
+            }
+        } finally {
+            LOCK.unlock();
+        }
     }
 
     @Override

--- a/src/test/java/com/example/extension/SeleniumMode.java
+++ b/src/test/java/com/example/extension/SeleniumMode.java
@@ -1,0 +1,29 @@
+package com.example.extension;
+
+import java.util.Locale;
+
+public enum SeleniumMode {
+    HOST,
+    CONTAINER;
+
+    private static final String PROPERTY_NAME = "selenium.mode";
+    private static final String ENVIRONMENT_NAME = "SELENIUM_MODE";
+
+    public static SeleniumMode current() {
+        return resolve(System.getProperty(PROPERTY_NAME), System.getenv(ENVIRONMENT_NAME));
+    }
+
+    static SeleniumMode resolve(String propertyValue, String environmentValue) {
+        String configuredValue = propertyValue == null || propertyValue.isBlank() ? environmentValue : propertyValue;
+        if (configuredValue == null || configuredValue.isBlank()) {
+            return HOST;
+        }
+        try {
+            return valueOf(configuredValue.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException(
+                    PROPERTY_NAME + " must be 'host' or 'container', but was '" + configuredValue + "'",
+                    exception);
+        }
+    }
+}

--- a/src/test/java/com/example/extension/SeleniumModeTest.java
+++ b/src/test/java/com/example/extension/SeleniumModeTest.java
@@ -1,0 +1,32 @@
+package com.example.extension;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class SeleniumModeTest {
+
+    @Test
+    void defaultsToHost() {
+        assertThat(SeleniumMode.resolve(null, null)).isEqualTo(SeleniumMode.HOST);
+    }
+
+    @Test
+    void readsEnvironmentValue() {
+        assertThat(SeleniumMode.resolve(null, "container")).isEqualTo(SeleniumMode.CONTAINER);
+    }
+
+    @Test
+    void propertyOverridesEnvironment() {
+        assertThat(SeleniumMode.resolve("host", "container")).isEqualTo(SeleniumMode.HOST);
+    }
+
+    @Test
+    void rejectsUnknownValue() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> SeleniumMode.resolve("remote", null))
+                .withMessageContaining("host")
+                .withMessageContaining("container");
+    }
+}

--- a/src/test/java/com/example/tests/BaseSeleniumIntegrationTest.java
+++ b/src/test/java/com/example/tests/BaseSeleniumIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.example.tests;
 
 import com.example.extension.SeleniumExtension;
+import com.example.extension.SeleniumMode;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.Testcontainers;
@@ -8,16 +9,22 @@ import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @ExtendWith(SeleniumExtension.class)
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 public abstract class BaseSeleniumIntegrationTest extends BaseIntegrationTest {
 
     protected final String seleniumBaseUrl;
 
     public BaseSeleniumIntegrationTest(int localServerPort, ObjectMapper objectMapper) {
         super(objectMapper);
-        Testcontainers.exposeHostPorts(localServerPort);
-        String hostForSelenium = System.getenv("HOST_FOR_SELENIUM") == null
-                ? "host.testcontainers.internal"
-                : System.getenv("HOST_FOR_SELENIUM");
+        SeleniumMode seleniumMode = SeleniumMode.current();
+        if (seleniumMode == SeleniumMode.CONTAINER) {
+            Testcontainers.exposeHostPorts(localServerPort);
+        }
+        String hostForSelenium = seleniumMode == SeleniumMode.HOST
+                ? "127.0.0.1"
+                : System.getenv("HOST_FOR_SELENIUM") == null
+                        ? "host.testcontainers.internal"
+                        : System.getenv("HOST_FOR_SELENIUM");
         // noinspection HttpUrlsUsage local url for tests
         this.seleniumBaseUrl = "http://" + hostForSelenium + ":" + localServerPort;
     }

--- a/src/test/java/com/example/util/LockUtils.java
+++ b/src/test/java/com/example/util/LockUtils.java
@@ -1,0 +1,26 @@
+package com.example.util;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
+
+public final class LockUtils {
+
+    private LockUtils() {
+    }
+
+    public static <T> T withLock(Lock lock, Supplier<T> action) {
+        lock.lock();
+        try {
+            return action.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public static void withLock(Lock lock, Runnable action) {
+        withLock(lock, () -> {
+            action.run();
+            return null;
+        });
+    }
+}

--- a/src/test/java/com/example/util/LockUtilsTest.java
+++ b/src/test/java/com/example/util/LockUtilsTest.java
@@ -1,0 +1,43 @@
+package com.example.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.example.util.LockUtils.withLock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LockUtilsTest {
+
+    @Test
+    void returnsValueWhileHoldingLock() {
+        ReentrantLock lock = new ReentrantLock();
+
+        boolean heldInsideAction = withLock(lock, lock::isHeldByCurrentThread);
+
+        assertThat(heldInsideAction).isTrue();
+        assertThat(lock.isLocked()).isFalse();
+    }
+
+    @Test
+    void runsVoidActionWhileHoldingLock() {
+        ReentrantLock lock = new ReentrantLock();
+        boolean[] heldInsideAction = {false};
+
+        withLock(lock, () -> heldInsideAction[0] = lock.isHeldByCurrentThread());
+
+        assertThat(heldInsideAction[0]).isTrue();
+        assertThat(lock.isLocked()).isFalse();
+    }
+
+    @Test
+    void unlocksWhenActionFails() {
+        ReentrantLock lock = new ReentrantLock();
+
+        assertThatThrownBy(() -> withLock(lock, () -> {
+            throw new IllegalStateException("expected");
+        })).isInstanceOf(IllegalStateException.class);
+        assertThat(lock.isLocked()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit `selenium.mode=host|container` selection with `SELENIUM_MODE` fallback
- default ordinary local and IDE runs to host Chrome via Selenium Manager
- preserve Testcontainers Chrome plus VNC MP4 recording in container mode
- make CI select container mode explicitly

## Precedence
1. `selenium.mode` JVM/Gradle property
2. `SELENIUM_MODE` environment variable
3. local default: `host`

## Validation
- committed candidate `ca95672ed1e75024a358737efc68a67398829e28`
- host: 8/8 Selenium scenarios, 8 PNG screenshots, 0 MP4
- container: 8/8 Selenium scenarios, 8 PNG screenshots, 1 MP4
- clean full container build: 51/51 tests plus JaCoCo, Spotless, PMD, SpotBugs, docs and archives
- warm offline build passed
- npm frontend build and workflow lint passed

## Local loop measurement
Controlled H/C/C/H execution on the committed candidate, with real test execution and the cache-restored non-executing attempt rejected:
- host: 53.2s, 46.6s (median 49.9s)
- container: 61.0s, 55.8s (median 58.4s)

This is local developer-loop evidence only.

Follow-up to the rejected experiment in #1120; this PR does not reopen or mutate it. This PR is stacked on the reviewed performance branch and should remain draft. #1125 and #1126 are already merged; this follow-up should merge only after review, after its base is retargeted to `master` if appropriate.