### PR TITLE
ACCEPT FOUNDATION/NEUTRAL: integrate #1136 runtime profiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY --from=builder /app/extracted/dependencies/ ./
 COPY --from=builder /app/extracted/application/ ./
 USER spring:spring
 
+ENV SPRING_PROFILES_ACTIVE=deployed
+
 RUN ls -lha
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ Spring Boot Aplication with Docker
 ```
 The Gradle build runs the frontend bundle step automatically.
 
+### Runtime profiles
+
+Runtime intent is explicit and does not use profile groups:
+
+- `./gradlew bootRun` activates `local-development`: Hibernate statistics, DEBUG web/SQL/timing logs, and the four
+  request context filters are enabled; JSF uses development stage.
+- Integration tests retain `@ActiveProfiles("test")`: statistics, JMX, verbose logging, and custom request filters are
+  disabled; JSF uses production stage.
+- The Docker image activates `deployed`: the same lean runtime defaults are explicit for deployed containers.
+- `--spring.profiles.active=profiling` opts into Hibernate statistics, JMX, Mojarra TRACE, verbose web/SQL logging, and
+  all four custom request filters.
+- Starting the executable JAR without a profile uses the lean defaults and is equivalent to the diagnostic settings of
+  `deployed`; select `deployed` explicitly for deployment automation outside the checked-in Docker image.
+
+All modes instantiate and expose only the required read-only Actuator endpoints: health, info, metrics, and Prometheus.
+Existing security rules remain responsible for HTTP authorization.
+
 Run the fast unit-only test loop without integration or Selenium tests:
 
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,6 +262,7 @@ tasks.withType<JavaCompile> {
 
 tasks.bootRun {
     systemProperty("spring.output.ansi.enabled", "always")
+    systemProperty("spring.profiles.active", providers.systemProperty("spring.profiles.active").getOrElse("local-development"))
     jvmArgs = listOf(
             "--add-opens=java.base/java.lang=ALL-UNNAMED",
             "--add-opens=java.base/java.math=ALL-UNNAMED",

--- a/src/main/resources/application-deployed.yaml
+++ b/src/main/resources/application-deployed.yaml
@@ -1,0 +1,22 @@
+spring:
+  jmx:
+    enabled: false
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: false
+
+joinfaces:
+  faces:
+    project-stage: production
+
+logging:
+  custom:
+    time:
+      enable: false
+    user:
+      enable: false
+    session:
+      enable: false
+    request:
+      enable: false

--- a/src/main/resources/application-local-development.yaml
+++ b/src/main/resources/application-local-development.yaml
@@ -1,0 +1,28 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+
+joinfaces:
+  faces:
+    project-stage: development
+
+logging:
+  level:
+    web: DEBUG
+    org:
+      springframework.web:
+        filter: debug
+      hibernate:
+        SQL: debug
+        stat: debug
+  custom:
+    time:
+      enable: true
+    user:
+      enable: true
+    session:
+      enable: true
+    request:
+      enable: true

--- a/src/main/resources/application-profiling.yaml
+++ b/src/main/resources/application-profiling.yaml
@@ -1,0 +1,35 @@
+spring:
+  jmx:
+    enabled: true
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+
+joinfaces:
+  faces:
+    project-stage: development
+
+logging:
+  level:
+    web: DEBUG
+    org:
+      springframework.web:
+        filter: debug
+      hibernate:
+        SQL: debug
+        stat: debug
+    com:
+      sun:
+        faces: trace
+    javax:
+      faces: trace
+  custom:
+    time:
+      enable: true
+    user:
+      enable: true
+    session:
+      enable: true
+    request:
+      enable: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ spring:
     show-sql: false
     properties:
       hibernate:
-        generate_statistics: true
+        generate_statistics: false
     open-in-view: false
 
   datasource:
@@ -22,7 +22,7 @@ spring:
     enabled: true
   #    drop-first: true
   jmx:
-    enabled: true
+    enabled: false
 
   cache:
     cache-names:
@@ -48,7 +48,7 @@ joinfaces:
   primefaces:
     theme: bootstrap
   faces:
-    project-stage: development
+    project-stage: production
     serialize-server-state: true
 
 server:
@@ -68,11 +68,20 @@ management:
       mode: full
   endpoint:
     health:
+      access: read-only
       show-details: when_authorized
+    info:
+      access: read-only
+    metrics:
+      access: read-only
+    prometheus:
+      access: read-only
   endpoints:
+    access:
+      default: none
     web:
       exposure:
-        include: '*'
+        include: health,info,metrics,prometheus
   metrics:
     web:
       server:
@@ -90,17 +99,17 @@ logging:
     console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} [rid=%X{rid} sid=%X{sid} \
 user=%X{userName}] %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
   level:
-    web: DEBUG
+    web: INFO
     org:
       apache.tomcat.util.scan.StandardJarScanner: error
       springframework.web:
-        filter: debug
+        filter: info
       #        servlet.DispatcherServlet: debug
       hibernate:
         engine: warn #info to show session times
         type: info #trace to show binding parameters
-        SQL: debug #debug to show generated sql
-        stat: debug #debug to show hql query times
+        SQL: info #debug to show generated sql
+        stat: info #debug to show hql query times
     com:
       sun:
         faces: info
@@ -113,13 +122,13 @@ user=%X{userName}] %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39
       faces: info
   custom:
     time:
-      enable: true
+      enable: false
     user:
-      enable: true
+      enable: false
     session:
-      enable: true
+      enable: false
     request:
-      enable: true
+      enable: false
 
 #logbook:
 #    exclude:

--- a/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
+++ b/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.example.tests;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.example.component.RequestIdFilter;
 import com.example.component.SessionIdFilter;
 import com.example.component.TimeLoggingFilter;
@@ -8,9 +10,14 @@ import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -22,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @Tag("integration")
 @ActiveProfiles(profiles = "profiling", inheritProfiles = false)
 @TestPropertySource(properties = "spring.jmx.enabled=true")
-class ProfilingProfileIntegrationTest extends BaseIntegrationTest {
+class ProfilingProfileIntegrationTest extends BaseRestIntegrationTest {
 
     private final ApplicationContext applicationContext;
     private final Environment environment;
@@ -30,11 +37,13 @@ class ProfilingProfileIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     ProfilingProfileIntegrationTest(
+            @LocalServerPort int localServerPort,
             ObjectMapper objectMapper,
+            RestTemplateBuilder restTemplateBuilder,
             ApplicationContext applicationContext,
             Environment environment,
             EntityManagerFactory entityManagerFactory) {
-        super(objectMapper);
+        super(localServerPort, objectMapper, restTemplateBuilder);
         this.applicationContext = applicationContext;
         this.environment = environment;
         this.entityManagerFactory = entityManagerFactory;
@@ -52,5 +61,26 @@ class ProfilingProfileIntegrationTest extends BaseIntegrationTest {
                 () -> assertThat(applicationContext.getBeansOfType(UserNameFilter.class)).hasSize(1),
                 () -> assertThat(applicationContext.getBeansOfType(TimeLoggingFilter.class)).hasSize(1)
         );
+    }
+
+    @Test
+    void profilingProfileExecutesRetainedFilters() {
+        Logger appLoggers = (Logger) LoggerFactory.getLogger("com.example");
+        Level originalLevel = appLoggers.getLevel();
+        try {
+            appLoggers.setLevel(Level.OFF);
+            ResponseEntity<String> responseEntity = this.restAnonymousTemplate.getForEntity("/", String.class);
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            appLoggers.setLevel(Level.DEBUG);
+            responseEntity = this.restAnonymousTemplate.getForEntity("/?profile=profiling", String.class);
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            appLoggers.setLevel(Level.INFO);
+            responseEntity = this.restAnonymousTemplate.getForEntity("/", String.class);
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        } finally {
+            appLoggers.setLevel(originalLevel);
+        }
     }
 }

--- a/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
+++ b/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
@@ -1,0 +1,56 @@
+package com.example.tests;
+
+import com.example.component.RequestIdFilter;
+import com.example.component.SessionIdFilter;
+import com.example.component.TimeLoggingFilter;
+import com.example.component.UserNameFilter;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.jmx.export.MBeanExporter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Tag("integration")
+@ActiveProfiles(profiles = "profiling", inheritProfiles = false)
+@TestPropertySource(properties = "spring.jmx.enabled=true")
+class ProfilingProfileIntegrationTest extends BaseIntegrationTest {
+
+    private final ApplicationContext applicationContext;
+    private final Environment environment;
+    private final EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    ProfilingProfileIntegrationTest(
+            ObjectMapper objectMapper,
+            ApplicationContext applicationContext,
+            Environment environment,
+            EntityManagerFactory entityManagerFactory) {
+        super(objectMapper);
+        this.applicationContext = applicationContext;
+        this.environment = environment;
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    @Test
+    void profilingProfileInstantiatesRetainedDiagnostics() {
+        assertAll(
+                () -> assertThat(environment.getActiveProfiles()).containsExactly("profiling"),
+                () -> assertThat(applicationContext.getBeansOfType(MBeanExporter.class)).hasSize(1),
+                () -> assertThat(entityManagerFactory.unwrap(SessionFactory.class).getStatistics().isStatisticsEnabled())
+                        .isTrue(),
+                () -> assertThat(applicationContext.getBeansOfType(RequestIdFilter.class)).hasSize(1),
+                () -> assertThat(applicationContext.getBeansOfType(SessionIdFilter.class)).hasSize(1),
+                () -> assertThat(applicationContext.getBeansOfType(UserNameFilter.class)).hasSize(1),
+                () -> assertThat(applicationContext.getBeansOfType(TimeLoggingFilter.class)).hasSize(1)
+        );
+    }
+}

--- a/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
+++ b/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
@@ -10,6 +10,8 @@ import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.restclient.RestTemplateBuilder;
@@ -64,6 +66,7 @@ class ProfilingProfileIntegrationTest extends BaseRestIntegrationTest {
     }
 
     @Test
+    @ResourceLock(value = "logback:com.example", mode = ResourceAccessMode.READ_WRITE)
     void profilingProfileExecutesRetainedFilters() {
         Logger appLoggers = (Logger) LoggerFactory.getLogger("com.example");
         Level originalLevel = appLoggers.getLevel();

--- a/src/test/java/com/example/tests/RestIntegrationTest.java
+++ b/src/test/java/com/example/tests/RestIntegrationTest.java
@@ -2,13 +2,22 @@ package com.example.tests;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import com.example.component.RequestIdFilter;
+import com.example.component.SessionIdFilter;
+import com.example.component.TimeLoggingFilter;
+import com.example.component.UserNameFilter;
+import jakarta.persistence.EntityManagerFactory;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -18,6 +27,8 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -32,9 +43,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Slf4j
 @Tag("integration")
 @SuppressWarnings({
+        "PMD.ExcessiveImports",
         "PMD.TooManyStaticImports"
 })
 class RestIntegrationTest extends BaseRestIntegrationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private WebEndpointsSupplier webEndpointsSupplier;
 
     @Autowired
     RestIntegrationTest(
@@ -120,5 +144,30 @@ class RestIntegrationTest extends BaseRestIntegrationTest {
         assertThat(payload)
                 .containsKey("git")
                 .containsKey("build");
+    }
+
+    @Test
+    void testProfileUsesLeanRuntimeSemantics() {
+        Set<String> webEndpointIds = webEndpointsSupplier.getEndpoints().stream()
+                .map(endpoint -> endpoint.getEndpointId().toString())
+                .collect(Collectors.toSet());
+
+        assertAll(
+                () -> assertThat(environment.getActiveProfiles()).containsExactly("test"),
+                () -> assertThat(environment.getProperty("spring.jmx.enabled", Boolean.class)).isFalse(),
+                () -> assertThat(environment.getProperty(
+                        "spring.jpa.properties.hibernate.generate_statistics", Boolean.class)).isFalse(),
+                () -> assertThat(environment.getProperty("joinfaces.faces.project-stage")).isEqualTo("production"),
+                () -> assertThat(entityManagerFactory.unwrap(SessionFactory.class).getStatistics().isStatisticsEnabled())
+                        .isFalse(),
+                () -> assertThat(webEndpointIds).containsExactlyInAnyOrder("health", "info", "metrics", "prometheus"),
+                () -> assertThat(applicationContext.containsBean("beansEndpoint")).isFalse(),
+                () -> assertThat(applicationContext.containsBean("envEndpoint")).isFalse(),
+                () -> assertThat(applicationContext.containsBean("mbeanExporter")).isFalse(),
+                () -> assertThat(applicationContext.getBeansOfType(RequestIdFilter.class)).isEmpty(),
+                () -> assertThat(applicationContext.getBeansOfType(SessionIdFilter.class)).isEmpty(),
+                () -> assertThat(applicationContext.getBeansOfType(UserNameFilter.class)).isEmpty(),
+                () -> assertThat(applicationContext.getBeansOfType(TimeLoggingFilter.class)).isEmpty()
+        );
     }
 }

--- a/src/test/java/com/example/tests/RestIntegrationTest.java
+++ b/src/test/java/com/example/tests/RestIntegrationTest.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
@@ -78,6 +80,7 @@ class RestIntegrationTest extends BaseRestIntegrationTest {
     }
 
     @Test
+    @ResourceLock(value = "logback:com.example", mode = ResourceAccessMode.READ_WRITE)
     void homeLogging() {
         Logger appLoggers = (Logger) LoggerFactory.getLogger("com.example");
         appLoggers.setLevel(Level.OFF);

--- a/src/test/java/com/example/tests/RuntimeProfileConfigurationTest.java
+++ b/src/test/java/com/example/tests/RuntimeProfileConfigurationTest.java
@@ -1,0 +1,102 @@
+package com.example.tests;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.PropertySourcesPropertyResolver;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RuntimeProfileConfigurationTest {
+
+    private static final List<String> REQUIRED_ENDPOINTS = List.of("health", "info", "metrics", "prometheus");
+
+    @Test
+    void defaultProfileIsLean() throws IOException {
+        assertLean(resolver());
+    }
+
+    @Test
+    void deployedProfileIsLean() throws IOException {
+        assertLean(resolver("application-deployed.yaml"));
+    }
+
+    @Test
+    void testProfileIsLean() throws IOException {
+        assertLean(resolver("application-test.yaml"));
+    }
+
+    @Test
+    void localDevelopmentProfileRetainsDevelopmentDiagnostics() throws IOException {
+        PropertySourcesPropertyResolver properties = resolver("application-local-development.yaml");
+
+        assertThat(properties.getProperty("spring.jpa.properties.hibernate.generate_statistics", Boolean.class))
+                .isTrue();
+        assertThat(properties.getProperty("spring.jmx.enabled", Boolean.class)).isFalse();
+        assertThat(properties.getProperty("joinfaces.faces.project-stage")).isEqualTo("development");
+        assertThat(properties.getProperty("logging.level.web")).isEqualTo("DEBUG");
+        assertCustomFilters(properties, true);
+        assertRequiredEndpoints(properties);
+    }
+
+    @Test
+    void profilingProfileRetainsAllProfilingDiagnostics() throws IOException {
+        PropertySourcesPropertyResolver properties = resolver("application-profiling.yaml");
+
+        assertThat(properties.getProperty("spring.jpa.properties.hibernate.generate_statistics", Boolean.class))
+                .isTrue();
+        assertThat(properties.getProperty("spring.jmx.enabled", Boolean.class)).isTrue();
+        assertThat(properties.getProperty("joinfaces.faces.project-stage")).isEqualTo("development");
+        assertThat(properties.getProperty("logging.level.web")).isEqualTo("DEBUG");
+        assertThat(properties.getProperty("logging.level.com.sun.faces")).isEqualTo("trace");
+        assertCustomFilters(properties, true);
+        assertRequiredEndpoints(properties);
+    }
+
+    private void assertLean(PropertySourcesPropertyResolver properties) {
+        assertThat(properties.getProperty("spring.jpa.properties.hibernate.generate_statistics", Boolean.class))
+                .isFalse();
+        assertThat(properties.getProperty("spring.jmx.enabled", Boolean.class)).isFalse();
+        assertThat(properties.getProperty("joinfaces.faces.project-stage")).isEqualTo("production");
+        assertThat(properties.getProperty("logging.level.web")).isEqualTo("INFO");
+        assertCustomFilters(properties, false);
+        assertRequiredEndpoints(properties);
+    }
+
+    private void assertCustomFilters(PropertySourcesPropertyResolver properties, boolean enabled) {
+        for (String filter : List.of("time", "user", "session", "request")) {
+            assertThat(properties.getProperty("logging.custom." + filter + ".enable", Boolean.class))
+                    .as("logging.custom.%s.enable", filter)
+                    .isEqualTo(enabled);
+        }
+    }
+
+    private void assertRequiredEndpoints(PropertySourcesPropertyResolver properties) {
+        assertThat(properties.getProperty("management.endpoints.access.default")).isEqualTo("none");
+        assertThat(properties.getProperty("management.endpoints.web.exposure.include"))
+                .isEqualTo(String.join(",", REQUIRED_ENDPOINTS));
+        for (String endpoint : REQUIRED_ENDPOINTS) {
+            assertThat(properties.getProperty("management.endpoint." + endpoint + ".access"))
+                    .as("management.endpoint.%s.access", endpoint)
+                    .isEqualTo("read-only");
+        }
+    }
+
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    private PropertySourcesPropertyResolver resolver(String... overlays) throws IOException {
+        MutablePropertySources propertySources = new MutablePropertySources();
+        YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+        for (String overlay : overlays) {
+            List<PropertySource<?>> sources = loader.load(overlay, new ClassPathResource(overlay));
+            sources.forEach(propertySources::addLast);
+        }
+        loader.load("application.yaml", new ClassPathResource("application.yaml"))
+                .forEach(propertySources::addLast);
+        return new PropertySourcesPropertyResolver(propertySources);
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,10 +1,22 @@
 spring:
   devtools.restart.enabled: false
+  jmx.enabled: false
+  jpa.properties.hibernate.generate_statistics: false
+
+joinfaces:
+  faces:
+    project-stage: production
 
 logging:
   level:
+    web: INFO
     com:
       sun:
-        faces: trace
+        faces: info
     javax:
-      faces: trace
+      faces: info
+  custom:
+    time.enable: false
+    user.enable: false
+    session.enable: false
+    request.enable: false


### PR DESCRIPTION
## Decision and separation

**ACCEPT FOUNDATION/NEUTRAL** for #1136 runtime-profile semantics and the accepted test-only coverage/logger-isolation repairs.

This PR makes **no startup or other performance claim**. It is the neutral foundation layer for campaign #1131. The measured changes remain isolated in stacked PR #1149.

Final delivery/readiness task: [019f5fff-52d1-7303-8778-0a2cc88e27d8](https://chatgpt.com/codex/tasks/019f5fff-52d1-7303-8778-0a2cc88e27d8).

## Recovery and exact topology

Prior final PR #1143 is an inaccessible ghost object: owner-authenticated REST returns 404, GraphQL returns `NOT_FOUND`, while Git pull refs and the original exact branch remain. This replacement uses a permanent collision-free alias at the identical accepted commit; no commit was created or rewritten and the original branch was not moved.

- Base: `master` (`90cf16625fad73fde1a80247cfd75a199d1cfd3d` at the final pre-readiness audit)
- Original accepted branch: `codex/perf-campaign-foundation-1131`
- PR head alias: `codex/perf-campaign-foundation-1131-pr-recovery`
- Head: `c46b0562d43d9f0fc87bd853e2355c09e0fc4ae2`
- Tree: `a176e23e3255a00fed109377118841010e0da8f7`
- Accepted #1136 patch ID: `9952af13212e3b854850ad1c1f40ed4ba26de4f5`
- Logger-isolation repair: two test files, six insertions, patch ID `516c18a12f0309628881ba3c26d3d65e94fda07a`

The foundation makes default, deployed, and test modes explicitly lean; retains development diagnostics in `local-development`; retains full diagnostics and JMX in `profiling`; and limits instantiated Actuator web endpoints to health, info, metrics, and Prometheus while preserving security. Coverage and isolation repairs are test-only. The two logger-mutating methods use the same method-level `READ_WRITE` resource lock; unrelated tests remain parallel.

## Exact-head validation, CI, and review

- Java 25 clean Gradle gate: `BUILD SUCCESSFUL in 2m 7s`; 65/65 tests; zero failures/errors/skips
- Selenium container 8/8; REST 7/7; profiling 2/2
- JaCoCo 328/328 source lines; all four retained filters have zero missed lines
- REST Docs, frontend, plain/boot archives, Spotless, PMD, and SpotBugs passed
- Two accepted focused isolation runs and the refresh gate each passed 9/9; the two locked methods never overlapped while their suites did
- Post-isolation adversarial rereview: [COMPLETE / ACCEPT FOUNDATION/NEUTRAL](https://chatgpt.com/codex/tasks/019f5f7f-1621-7081-b964-021df37b1fa4), zero actionable findings, F1 closed
- Hosted run [29319290112](https://github.com/kamkie/demo-spring-jsf/actions/runs/29319290112), attempt 1, exact head `c46b0562`: terminal success
- Eight green contexts: `build`, `Test Results`, `PMD`, `spotbugs`, `CodeQL`, `Trivy`, `codecov/project`, `codecov/patch`
- Current-head reviews: zero; review threads: zero; current-head `CHANGES_REQUESTED`: zero

## Limitations and delivery boundary

- No timing cohort or performance result is attributed to this PR.
- Frozen campaign measurements and `NO_RERUN` belong to #1149.
- Literal Linux `172.17.0.1` Docker-to-host Selenium routing remains reduced coverage on Windows Docker Desktop; supported Windows host/container routes passed.
- The old #1143 object remains inaccessible; this recovery PR is canonical delivery.
- This task may mark readiness only after an immediate exact-head/base/master/ref/check/review/thread re-fetch. It may not merge or enable auto-merge.

Recommended merge order: **#1148 first, then #1149**. After #1148 is merged, #1149's stacked base must be handled through the normal GitHub merge flow without rewriting its accepted head.

Durable evidence roots:

- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\integration-foundation`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\foundation-logger-isolation-fix`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\post-isolation-final-revalidation`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\post-isolation-adversarial-rereview`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\hosted-ci-final-retry`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\final-delivery-readiness`
