### PR TITLE
ACCEPT PERFORMANCE: integrate measured startup campaign (#1131)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 **
 !build/libs
+!scripts/aot-train.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache postgresql18=18.4-r0
 COPY --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --from=builder /app/extracted/dependencies/ ./
 COPY --from=builder /app/extracted/application/ ./
-COPY scripts/aot-train.sh /usr/local/bin/aot-train
+COPY --chmod=0755 scripts/aot-train.sh /usr/local/bin/aot-train
 
 ENV SPRING_PROFILES_ACTIVE=deployed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:25 AS base
+FROM azul/zulu-openjdk-alpine:25@sha256:a772cce2bb079795bb02a3637275fbfa885893ca5014eb8c84e2e1c027aa48da AS base
 RUN addgroup -S spring && adduser -S spring -G spring
 RUN mkdir /app
 WORKDIR /app
@@ -8,15 +8,26 @@ ARG JAR_FILE=build/libs/demo-spring-jsf-*-boot.jar
 COPY ${JAR_FILE} app.jar
 RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted/
 
-FROM base AS runnable
+FROM base AS trainer
+
+RUN apk add --no-cache postgresql18=18.4-r0
 
 COPY --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --from=builder /app/extracted/dependencies/ ./
 COPY --from=builder /app/extracted/application/ ./
+COPY scripts/aot-train.sh /usr/local/bin/aot-train
+
+ENV SPRING_PROFILES_ACTIVE=deployed
+
+RUN /usr/local/bin/aot-train
+
+FROM base AS runnable
+
+COPY --from=trainer /app/ ./
 USER spring:spring
 
 ENV SPRING_PROFILES_ACTIVE=deployed
 
 RUN ls -lha
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-XX:AOTMode=on", "-XX:AOTCache=/app/application.aot", "-Xlog:aot=info", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Runtime intent is explicit and does not use profile groups:
 - Starting the executable JAR without a profile uses the lean defaults and is equivalent to the diagnostic settings of
   `deployed`; select `deployed` explicitly for deployment automation outside the checked-in Docker image.
 
+Boot and plain archives precompute JoinFaces scan metadata with the fixed `deployed` profile. Tests do not consume this
+metadata; their `test` profile and test runtime classpath continue to be scanned independently.
+
 All modes instantiate and expose only the required read-only Actuator endpoints: health, info, metrics, and Prometheus.
 Existing security rules remain responsible for HTTP authorization.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ and VNC MP4 recording. When `host.testcontainers.internal` is unavailable in con
 On Windows, host mode keeps Chrome headed on a dedicated Windows desktop so a local Selenium run cannot activate over the
 current application. Non-Windows host runs and container mode keep their existing headed browser behavior.
 
+### Reusing the test database locally
+
+Repeated local test invocations can retain the project Testcontainers PostgreSQL instance. This is an experimental,
+developer-only opt-in and is always disabled when a CI environment variable is present. Enable both required flags in
+PowerShell:
+
+```powershell
+$env:TESTCONTAINERS_REUSE_ENABLE = 'true'
+.\gradlew.bat test -Ptestcontainers.reuse=true
+```
+
+On POSIX shells:
+
+```sh
+export TESTCONTAINERS_REUSE_ENABLE=true
+./gradlew test -Ptestcontainers.reuse=true
+```
+
+Each invocation takes an advisory lock for its full test JVM lifetime, removes and recreates the `public` schema, and
+then lets Liquibase rebuild schema and seed data. Do not use the retained database for application data. Disable reuse
+with `Remove-Item Env:TESTCONTAINERS_REUSE_ENABLE` (PowerShell) or `unset TESTCONTAINERS_REUSE_ENABLE` (POSIX), and omit
+the Gradle property. Remove only this project's retained containers with:
+
+```powershell
+docker ps -aq --filter "label=com.example.demo-spring-jsf.reusable-postgres=true" |
+    ForEach-Object { docker rm -f $_ }
+```
+
+```sh
+for container in $(docker ps -aq --filter "label=com.example.demo-spring-jsf.reusable-postgres=true"); do
+    docker rm -f "$container"
+done
+```
+
 ### Docker
 Install Docker.
 Run the Docker image, by executing the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,16 @@ import com.github.spotbugs.snom.SpotBugsTask
 import com.palantir.gradle.gitversion.CommonGitOperations
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.api.tasks.Sync
+import org.gradle.jvm.tasks.Jar
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
+import org.springframework.boot.gradle.tasks.aot.ProcessAot
+import org.springframework.boot.gradle.tasks.bundling.BootJar
 import org.springframework.boot.gradle.util.VersionExtractor
 import java.io.Serializable
 import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
+import java.util.zip.ZipFile
 
 buildscript {
     repositories {
@@ -276,6 +281,38 @@ tasks.bootRun {
     }
 }
 
+val joinFacesMetadataProfile = "deployed"
+val generateJoinFacesMetadata = tasks.register<ProcessAot>("generateJoinFacesMetadata") {
+    group = "build"
+    description = "Generates JoinFaces scan metadata from Spring AOT processors."
+    dependsOn(tasks.named("classes"))
+    applicationMainClass.set("com.example.DemoApplication")
+    sourcesOutput.set(layout.buildDirectory.dir("generated/joinFacesAot/sources"))
+    resourcesOutput.set(layout.buildDirectory.dir("generated/joinFacesAot/resources"))
+    classesOutput.set(layout.buildDirectory.dir("generated/joinFacesAot/classes"))
+    groupId.set(project.group.toString())
+    artifactId.set(project.name)
+    classpath = files(sourceSets.main.get().output, configurations.named("productionRuntimeClasspath"))
+    args("--spring.profiles.active=$joinFacesMetadataProfile")
+}
+
+val generatedJoinFacesMetadata = generateJoinFacesMetadata
+    .flatMap(ProcessAot::getResourcesOutput)
+    .map { it.dir("META-INF/joinfaces") }
+val preparedJoinFacesMetadata = layout.buildDirectory.dir("generated/joinFacesMetadata")
+val prepareJoinFacesMetadata = tasks.register<Sync>("prepareJoinFacesMetadata") {
+    dependsOn(generateJoinFacesMetadata)
+    from(generatedJoinFacesMetadata)
+    into(preparedJoinFacesMetadata)
+    outputs.cacheIf("Prepared metadata is fully declared and normalized") { true }
+    doLast {
+        preparedJoinFacesMetadata.get().asFile.listFiles()?.filter { it.isFile }?.forEach { file ->
+            val sortedLines = file.readLines(StandardCharsets.UTF_8).sorted()
+            file.writeText(if (sortedLines.isEmpty()) "" else sortedLines.joinToString("\n", postfix = "\n"), StandardCharsets.UTF_8)
+        }
+    }
+}
+
 val asciidoctorTask = tasks.register<JavaExec>("asciidoctor") {
     group = "documentation"
     description = "Generates the Spring REST Docs reference documentation."
@@ -310,12 +347,104 @@ val asciidoctorTask = tasks.register<JavaExec>("asciidoctor") {
 
 tasks.bootJar {
     archiveClassifier.set("boot")
+    dependsOn(prepareJoinFacesMetadata)
+    from(preparedJoinFacesMetadata) {
+        into("BOOT-INF/classes/META-INF/joinfaces")
+    }
     from(asciidoctorTask) {
         into("BOOT-INF/classes/static/docs")
     }
     layered {
         enabled.set(true)
     }
+}
+
+tasks.jar {
+    dependsOn(prepareJoinFacesMetadata)
+    from(preparedJoinFacesMetadata) {
+        into("META-INF/joinfaces")
+    }
+}
+
+val verifyJoinFacesMetadata = tasks.register("verifyJoinFacesMetadata") {
+    group = "verification"
+    description = "Verifies generated and packaged JoinFaces scan metadata."
+    val expectedFiles = listOf(
+            "com.sun.faces.config.FacesInitializer.classes",
+            "com.sun.faces.config.FacesInitializer2.classes",
+            "com.sun.faces.spi.AnnotationProvider.classes",
+    )
+    val plainJar = tasks.named<Jar>("jar").flatMap(Jar::getArchiveFile)
+    val bootJar = tasks.named<BootJar>("bootJar").flatMap(BootJar::getArchiveFile)
+    dependsOn(prepareJoinFacesMetadata, plainJar, bootJar)
+    inputs.dir(preparedJoinFacesMetadata)
+    inputs.files(plainJar, bootJar)
+    inputs.property("profile", joinFacesMetadataProfile)
+
+    doLast {
+        check(joinFacesMetadataProfile == "deployed") {
+            "JoinFaces runtime metadata must be generated with the deployed profile"
+        }
+        val metadataDirectory = preparedJoinFacesMetadata.get().asFile
+        val actualFiles = metadataDirectory.walkTopDown()
+            .filter { it.isFile }
+            .map { it.relativeTo(metadataDirectory).invariantSeparatorsPath }
+            .toList()
+        check(actualFiles.sorted() == expectedFiles.sorted()) {
+            "Expected exactly $expectedFiles but found $actualFiles"
+        }
+        val archives = listOf(
+                plainJar.get().asFile to "META-INF/joinfaces/",
+                bootJar.get().asFile to "BOOT-INF/classes/META-INF/joinfaces/",
+        )
+        archives.forEach { (archive, prefix) ->
+            ZipFile(archive).use { zip ->
+                val packagedFiles = zip.entries().asSequence()
+                    .filter { !it.isDirectory && it.name.startsWith(prefix) }
+                    .map { it.name.removePrefix(prefix) }
+                    .toList()
+                check(packagedFiles.sorted() == expectedFiles.sorted()) {
+                    "Expected exactly $expectedFiles under $prefix in ${archive.name}, found $packagedFiles"
+                }
+            }
+        }
+
+        expectedFiles.forEach { fileName ->
+            val generatedFile = metadataDirectory.resolve(fileName)
+            val lines = generatedFile.readLines(StandardCharsets.UTF_8)
+            when (fileName) {
+                "com.sun.faces.config.FacesInitializer.classes" -> {
+                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
+                    check(lines == lines.sorted().distinct()) { "$fileName must be sorted and contain no duplicates" }
+                }
+                "com.sun.faces.config.FacesInitializer2.classes" ->
+                    check(lines.isEmpty()) { "$fileName is expected to be an empty prepared result" }
+                "com.sun.faces.spi.AnnotationProvider.classes" -> {
+                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
+                    val keys = lines.map { it.substringBefore('=', missingDelimiterValue = "") }
+                    check(keys.none(String::isBlank) && keys.distinct().size == keys.size) {
+                        "$fileName must contain unique annotation keys"
+                    }
+                }
+            }
+
+            archives.forEach { (archive, prefix) ->
+                val entryName = "$prefix$fileName"
+                ZipFile(archive).use { zip ->
+                    val entries = zip.entries().asSequence().filter { it.name == entryName }.toList()
+                    check(entries.size == 1) { "Expected one $entryName in ${archive.name}, found ${entries.size}" }
+                    val packagedBytes = zip.getInputStream(entries.single()).use { it.readAllBytes() }
+                    check(packagedBytes.contentEquals(generatedFile.readBytes())) {
+                        "$entryName in ${archive.name} is stale or incomplete"
+                    }
+                }
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(verifyJoinFacesMetadata)
 }
 
 tasks.jacocoTestReport {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,24 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.github.gradle.node.task.NodeTask
 import com.github.spotbugs.snom.SpotBugsTask
 import com.palantir.gradle.gitversion.CommonGitOperations
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.gradle.api.tasks.Sync
 import org.gradle.jvm.tasks.Jar
+import org.gradle.work.DisableCachingByDefault
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.aot.ProcessAot
 import org.springframework.boot.gradle.tasks.bundling.BootJar
@@ -15,6 +29,130 @@ import java.io.Serializable
 import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 import java.util.zip.ZipFile
+import javax.inject.Inject
+
+@CacheableTask
+abstract class PrepareJoinFacesMetadata : DefaultTask() {
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceDirectory: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val destinationDirectory: DirectoryProperty
+
+    @get:Inject
+    abstract val fileSystemOperations: FileSystemOperations
+
+    @TaskAction
+    fun prepare() {
+        val source = sourceDirectory.get().asFile
+        val destination = destinationDirectory.get().asFile
+        fileSystemOperations.delete { delete(destination) }
+        fileSystemOperations.copy {
+            from(source)
+            into(destination)
+        }
+        destination.listFiles()?.filter { it.isFile }?.forEach { file ->
+            val sortedLines = file.readLines(StandardCharsets.UTF_8).sorted()
+            file.writeText(
+                    if (sortedLines.isEmpty()) "" else sortedLines.joinToString("\n", postfix = "\n"),
+                    StandardCharsets.UTF_8,
+            )
+        }
+    }
+}
+
+@DisableCachingByDefault(because = "Verification task has no outputs")
+abstract class VerifyJoinFacesMetadata : DefaultTask() {
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val metadataDirectory: DirectoryProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val plainArchive: RegularFileProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val bootArchive: RegularFileProperty
+
+    @get:Input
+    abstract val profile: Property<String>
+
+    @get:Input
+    abstract val expectedFiles: ListProperty<String>
+
+    @get:Input
+    abstract val plainPrefix: Property<String>
+
+    @get:Input
+    abstract val bootPrefix: Property<String>
+
+    @TaskAction
+    fun verify() {
+        check(profile.get() == "deployed") {
+            "JoinFaces runtime metadata must be generated with the deployed profile"
+        }
+        val expected = expectedFiles.get()
+        val metadata = metadataDirectory.get().asFile
+        val actualFiles = metadata.walkTopDown()
+            .filter { it.isFile }
+            .map { it.relativeTo(metadata).invariantSeparatorsPath }
+            .toList()
+        check(actualFiles.sorted() == expected.sorted()) {
+            "Expected exactly $expected but found $actualFiles"
+        }
+        val archives = listOf(
+                plainArchive.get().asFile to plainPrefix.get(),
+                bootArchive.get().asFile to bootPrefix.get(),
+        )
+        archives.forEach { (archive, prefix) ->
+            ZipFile(archive).use { zip ->
+                val packagedFiles = zip.entries().asSequence()
+                    .filter { !it.isDirectory && it.name.startsWith(prefix) }
+                    .map { it.name.removePrefix(prefix) }
+                    .toList()
+                check(packagedFiles.sorted() == expected.sorted()) {
+                    "Expected exactly $expected under $prefix in ${archive.name}, found $packagedFiles"
+                }
+            }
+        }
+
+        expected.forEach { fileName ->
+            val generatedFile = metadata.resolve(fileName)
+            val lines = generatedFile.readLines(StandardCharsets.UTF_8)
+            when (fileName) {
+                "com.sun.faces.config.FacesInitializer.classes" -> {
+                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
+                    check(lines == lines.sorted().distinct()) { "$fileName must be sorted and contain no duplicates" }
+                }
+                "com.sun.faces.config.FacesInitializer2.classes" ->
+                    check(lines.isEmpty()) { "$fileName is expected to be an empty prepared result" }
+                "com.sun.faces.spi.AnnotationProvider.classes" -> {
+                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
+                    val keys = lines.map { it.substringBefore('=', missingDelimiterValue = "") }
+                    check(keys.none(String::isBlank) && keys.distinct().size == keys.size) {
+                        "$fileName must contain unique annotation keys"
+                    }
+                }
+            }
+
+            archives.forEach { (archive, prefix) ->
+                val entryName = "$prefix$fileName"
+                ZipFile(archive).use { zip ->
+                    val entries = zip.entries().asSequence().filter { it.name == entryName }.toList()
+                    check(entries.size == 1) { "Expected one $entryName in ${archive.name}, found ${entries.size}" }
+                    val packagedBytes = zip.getInputStream(entries.single()).use { it.readAllBytes() }
+                    check(packagedBytes.contentEquals(generatedFile.readBytes())) {
+                        "$entryName in ${archive.name} is stale or incomplete"
+                    }
+                }
+            }
+        }
+    }
+}
 
 buildscript {
     repositories {
@@ -300,17 +438,12 @@ val generatedJoinFacesMetadata = generateJoinFacesMetadata
     .flatMap(ProcessAot::getResourcesOutput)
     .map { it.dir("META-INF/joinfaces") }
 val preparedJoinFacesMetadata = layout.buildDirectory.dir("generated/joinFacesMetadata")
-val prepareJoinFacesMetadata = tasks.register<Sync>("prepareJoinFacesMetadata") {
+val prepareJoinFacesMetadata = tasks.register<PrepareJoinFacesMetadata>("prepareJoinFacesMetadata") {
+    group = "build"
+    description = "Prepares deterministic JoinFaces scan metadata for packaging."
     dependsOn(generateJoinFacesMetadata)
-    from(generatedJoinFacesMetadata)
-    into(preparedJoinFacesMetadata)
-    outputs.cacheIf("Prepared metadata is fully declared and normalized") { true }
-    doLast {
-        preparedJoinFacesMetadata.get().asFile.listFiles()?.filter { it.isFile }?.forEach { file ->
-            val sortedLines = file.readLines(StandardCharsets.UTF_8).sorted()
-            file.writeText(if (sortedLines.isEmpty()) "" else sortedLines.joinToString("\n", postfix = "\n"), StandardCharsets.UTF_8)
-        }
-    }
+    sourceDirectory.set(generatedJoinFacesMetadata)
+    destinationDirectory.set(preparedJoinFacesMetadata)
 }
 
 val asciidoctorTask = tasks.register<JavaExec>("asciidoctor") {
@@ -366,81 +499,23 @@ tasks.jar {
     }
 }
 
-val verifyJoinFacesMetadata = tasks.register("verifyJoinFacesMetadata") {
+val verifyJoinFacesMetadata = tasks.register<VerifyJoinFacesMetadata>("verifyJoinFacesMetadata") {
     group = "verification"
     description = "Verifies generated and packaged JoinFaces scan metadata."
-    val expectedFiles = listOf(
+    expectedFiles.set(listOf(
             "com.sun.faces.config.FacesInitializer.classes",
             "com.sun.faces.config.FacesInitializer2.classes",
             "com.sun.faces.spi.AnnotationProvider.classes",
-    )
-    val plainJar = tasks.named<Jar>("jar").flatMap(Jar::getArchiveFile)
-    val bootJar = tasks.named<BootJar>("bootJar").flatMap(BootJar::getArchiveFile)
-    dependsOn(prepareJoinFacesMetadata, plainJar, bootJar)
-    inputs.dir(preparedJoinFacesMetadata)
-    inputs.files(plainJar, bootJar)
-    inputs.property("profile", joinFacesMetadataProfile)
-
-    doLast {
-        check(joinFacesMetadataProfile == "deployed") {
-            "JoinFaces runtime metadata must be generated with the deployed profile"
-        }
-        val metadataDirectory = preparedJoinFacesMetadata.get().asFile
-        val actualFiles = metadataDirectory.walkTopDown()
-            .filter { it.isFile }
-            .map { it.relativeTo(metadataDirectory).invariantSeparatorsPath }
-            .toList()
-        check(actualFiles.sorted() == expectedFiles.sorted()) {
-            "Expected exactly $expectedFiles but found $actualFiles"
-        }
-        val archives = listOf(
-                plainJar.get().asFile to "META-INF/joinfaces/",
-                bootJar.get().asFile to "BOOT-INF/classes/META-INF/joinfaces/",
-        )
-        archives.forEach { (archive, prefix) ->
-            ZipFile(archive).use { zip ->
-                val packagedFiles = zip.entries().asSequence()
-                    .filter { !it.isDirectory && it.name.startsWith(prefix) }
-                    .map { it.name.removePrefix(prefix) }
-                    .toList()
-                check(packagedFiles.sorted() == expectedFiles.sorted()) {
-                    "Expected exactly $expectedFiles under $prefix in ${archive.name}, found $packagedFiles"
-                }
-            }
-        }
-
-        expectedFiles.forEach { fileName ->
-            val generatedFile = metadataDirectory.resolve(fileName)
-            val lines = generatedFile.readLines(StandardCharsets.UTF_8)
-            when (fileName) {
-                "com.sun.faces.config.FacesInitializer.classes" -> {
-                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
-                    check(lines == lines.sorted().distinct()) { "$fileName must be sorted and contain no duplicates" }
-                }
-                "com.sun.faces.config.FacesInitializer2.classes" ->
-                    check(lines.isEmpty()) { "$fileName is expected to be an empty prepared result" }
-                "com.sun.faces.spi.AnnotationProvider.classes" -> {
-                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
-                    val keys = lines.map { it.substringBefore('=', missingDelimiterValue = "") }
-                    check(keys.none(String::isBlank) && keys.distinct().size == keys.size) {
-                        "$fileName must contain unique annotation keys"
-                    }
-                }
-            }
-
-            archives.forEach { (archive, prefix) ->
-                val entryName = "$prefix$fileName"
-                ZipFile(archive).use { zip ->
-                    val entries = zip.entries().asSequence().filter { it.name == entryName }.toList()
-                    check(entries.size == 1) { "Expected one $entryName in ${archive.name}, found ${entries.size}" }
-                    val packagedBytes = zip.getInputStream(entries.single()).use { it.readAllBytes() }
-                    check(packagedBytes.contentEquals(generatedFile.readBytes())) {
-                        "$entryName in ${archive.name} is stale or incomplete"
-                    }
-                }
-            }
-        }
-    }
+    ))
+    val plainJarTask = tasks.named<Jar>("jar")
+    val bootJarTask = tasks.named<BootJar>("bootJar")
+    dependsOn(prepareJoinFacesMetadata, plainJarTask, bootJarTask)
+    metadataDirectory.set(preparedJoinFacesMetadata)
+    plainArchive.set(plainJarTask.flatMap(Jar::getArchiveFile))
+    bootArchive.set(bootJarTask.flatMap(BootJar::getArchiveFile))
+    profile.set(joinFacesMetadataProfile)
+    plainPrefix.set("META-INF/joinfaces/")
+    bootPrefix.set("BOOT-INF/classes/META-INF/joinfaces/")
 }
 
 tasks.check {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,6 @@ val jnaVersion = "5.19.1"
 val seleniumVersion = "4.46.0"
 val asciiDoctorJVersion = "3.0.1"
 val picocliVersion = "4.7.7"
-val spotbugsAnnotationsVersion = "4.10.3"
 val logstashLogbackEncoderVersion = "9.0"
 val joinfacesVersion = "6.1.0"
 val primefacesThemesVersion = "1.1.0"
@@ -94,6 +93,9 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     annotationProcessor("org.springframework:spring-context-indexer")
 
+    compileOnly("org.projectlombok:lombok")
+    testCompileOnly("org.projectlombok:lombok")
+
     asciidoctorRuntime("org.asciidoctor:asciidoctorj:$asciiDoctorJVersion")
     asciidoctorRuntime("org.asciidoctor:asciidoctorj-cli:$asciiDoctorJVersion")
     asciidoctorRuntime("org.springframework.restdocs:spring-restdocs-asciidoctor")
@@ -104,10 +106,6 @@ dependencies {
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 
-    implementation("com.github.spotbugs:spotbugs-annotations:$spotbugsAnnotationsVersion")
-    implementation("org.projectlombok:lombok")
-
-    implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-aspectj")
     implementation("org.springframework.boot:spring-boot-starter-cache")
@@ -115,7 +113,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.boot:spring-boot-restclient")
     implementation("org.springframework.boot:spring-boot-session")
     implementation("org.springframework.session:spring-session-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
@@ -134,6 +131,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    testImplementation("org.springframework.boot:spring-boot-restclient")
     testImplementation("org.springframework.boot:spring-boot-resttestclient")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
     testImplementation("org.springframework.boot:spring-boot-starter-session-jdbc-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -540,6 +540,13 @@ tasks.withType<Test> {
         .orElse(providers.environmentVariable("SELENIUM_MODE"))
         .orNull
         ?.let { systemProperty("selenium.mode", it) }
+    val ciEnvironment = listOf("CI", "GITHUB_ACTIONS", "JENKINS_URL", "BUILD_NUMBER")
+        .any { providers.environmentVariable(it).isPresent }
+    val reuseRequested = providers.gradleProperty("testcontainers.reuse")
+        .orElse(providers.systemProperty("testcontainers.reuse"))
+        .map(String::toBoolean)
+        .getOrElse(false)
+    systemProperty("testcontainers.reuse", reuseRequested && !ciEnvironment)
     jvmArgs = listOf(
             "-XX:+EnableDynamicAgentLoading",
             "--enable-native-access=ALL-UNNAMED",

--- a/scripts/aot-train.sh
+++ b/scripts/aot-train.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+set -eu
+
+postgres_data=/tmp/postgresql
+postgres_socket=/tmp/postgresql-socket
+postgres_started=false
+application_pid=
+
+cleanup() {
+    if [ -n "$application_pid" ] && kill -0 "$application_pid" 2>/dev/null; then
+        kill -TERM "$application_pid"
+        wait "$application_pid" || true
+    fi
+    if [ "$postgres_started" = true ]; then
+        su postgres -s /bin/sh -c "pg_ctl -D '$postgres_data' -m fast -w stop" >/dev/null
+    fi
+}
+trap cleanup EXIT INT TERM
+
+install -d -o postgres -g postgres "$postgres_data" "$postgres_socket"
+printf 'dev\n' >/tmp/postgresql-password
+chown postgres:postgres /tmp/postgresql-password
+chmod 600 /tmp/postgresql-password
+su postgres -s /bin/sh -c \
+    "initdb -D '$postgres_data' --username=dev --pwfile=/tmp/postgresql-password --auth-local=trust --auth-host=scram-sha-256" \
+    >/dev/null
+su postgres -s /bin/sh -c \
+    "pg_ctl -D '$postgres_data' -o '-h 127.0.0.1 -k $postgres_socket -p 5432' -w start" \
+    >/dev/null
+postgres_started=true
+su postgres -s /bin/sh -c "createdb -h '$postgres_socket' -p 5432 -U dev spring-demo"
+
+export SPRING_DATASOURCE_URL=jdbc:postgresql://127.0.0.1:5432/spring-demo
+export SPRING_DATASOURCE_USERNAME=dev
+export SPRING_DATASOURCE_PASSWORD=dev
+su spring -s /bin/sh -c \
+    'exec java -XX:AOTCacheOutput=/tmp/application.aot -Xlog:aot=info -jar app.jar' &
+application_pid=$!
+
+attempt=0
+until wget -q -T 2 -O /dev/null http://127.0.0.1:8080/actuator/health; do
+    if ! kill -0 "$application_pid" 2>/dev/null; then
+        wait "$application_pid"
+    fi
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 900 ]; then
+        echo 'Application did not become ready during AOT training.' >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+
+for path in / /admin /table.xhtml; do
+    wget -q -T 10 -O /dev/null "http://127.0.0.1:8080$path"
+done
+
+kill -TERM "$application_pid"
+set +e
+wait "$application_pid"
+application_status=$?
+set -e
+application_pid=
+if [ "$application_status" -ne 0 ] && [ "$application_status" -ne 143 ]; then
+    echo "AOT training application exited with status $application_status." >&2
+    exit "$application_status"
+fi
+if [ ! -s /tmp/application.aot ]; then
+    echo 'AOT training did not produce /tmp/application.aot.' >&2
+    exit 1
+fi
+install -o root -g root -m 0444 /tmp/application.aot /app/application.aot

--- a/src/test/java/com/example/extension/DockerExtension.java
+++ b/src/test/java/com/example/extension/DockerExtension.java
@@ -3,7 +3,12 @@ package com.example.extension;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.Extension;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -11,26 +16,96 @@ import java.util.concurrent.locks.ReentrantLock;
 @SuppressWarnings("PMD.DoNotUseThreads")
 public class DockerExtension implements Extension {
 
-    private static final PostgreSQLContainer POSTGRES_SQL_CONTAINER = new PostgreSQLContainer("postgres:17.10");
+    private static final String REUSE_PROPERTY = "testcontainers.reuse";
+    private static final String REUSE_LABEL = "com.example.demo-spring-jsf.reusable-postgres";
+    private static final long REUSE_LOCK_ID = 1_137L;
+    private static final boolean REUSE_ENABLED = reuseEnabled();
+    private static final PostgreSQLContainer POSTGRES_SQL_CONTAINER = postgresContainer();
     private static final Lock LOCK = new ReentrantLock();
+    private static Connection reuseLockConnection;
 
     public static PostgreSQLContainer getPostgres() {
-        if (!POSTGRES_SQL_CONTAINER.isRunning()) {
-            LOCK.lock();
-            try {
-                if (!POSTGRES_SQL_CONTAINER.isRunning()) {
-                    log.info("starting postgres container");
-                    POSTGRES_SQL_CONTAINER.start();
-                    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                        log.info("stopping postgres container");
-                        POSTGRES_SQL_CONTAINER.stop();
-                    }));
-                }
-            } finally {
-                LOCK.unlock();
+        if (POSTGRES_SQL_CONTAINER.isRunning()) {
+            return POSTGRES_SQL_CONTAINER;
+        }
+        LOCK.lock();
+        try {
+            if (POSTGRES_SQL_CONTAINER.isRunning()) {
+                return POSTGRES_SQL_CONTAINER;
             }
+            log.info("starting postgres container");
+            POSTGRES_SQL_CONTAINER.start();
+            if (REUSE_ENABLED) {
+                resetReusableDatabase();
+            } else {
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    log.info("stopping postgres container");
+                    POSTGRES_SQL_CONTAINER.stop();
+                }));
+            }
+        } finally {
+            LOCK.unlock();
         }
         return POSTGRES_SQL_CONTAINER;
+    }
+
+    private static boolean reuseEnabled() {
+        if (!Boolean.getBoolean(REUSE_PROPERTY) || isCi()) {
+            return false;
+        }
+        if (!TestcontainersConfiguration.getInstance().environmentSupportsReuse()) {
+            throw new IllegalStateException(
+                    "Reusable PostgreSQL requires TESTCONTAINERS_REUSE_ENABLE=true in addition to -D"
+                            + REUSE_PROPERTY + "=true"
+            );
+        }
+        return true;
+    }
+
+    private static PostgreSQLContainer postgresContainer() {
+        PostgreSQLContainer container = new PostgreSQLContainer("postgres:17.10");
+        if (REUSE_ENABLED) {
+            container.withLabel(REUSE_LABEL, "true").withReuse(true);
+        }
+        return container;
+    }
+
+    private static boolean isCi() {
+        return System.getenv("CI") != null
+                || System.getenv("GITHUB_ACTIONS") != null
+                || System.getenv("JENKINS_URL") != null
+                || System.getenv("BUILD_NUMBER") != null;
+    }
+
+    private static void resetReusableDatabase() {
+        try {
+            reuseLockConnection = openResetConnection();
+            log.info("reset reusable postgres schema and retained advisory lock {} for this test JVM", REUSE_LOCK_ID);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Could not reset reusable PostgreSQL before Spring startup", e);
+        }
+    }
+
+    private static Connection openResetConnection() throws SQLException {
+        Connection connection = DriverManager.getConnection(
+                POSTGRES_SQL_CONTAINER.getJdbcUrl(),
+                POSTGRES_SQL_CONTAINER.getUsername(),
+                POSTGRES_SQL_CONTAINER.getPassword()
+        );
+        try {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SET lock_timeout = '120s'");
+                statement.execute("SELECT pg_advisory_lock(" + REUSE_LOCK_ID + ")");
+                statement.execute("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                        + "WHERE datname = current_database() AND pid <> pg_backend_pid()");
+                statement.execute("DROP SCHEMA IF EXISTS public CASCADE");
+                statement.execute("CREATE SCHEMA public");
+            }
+            return connection;
+        } catch (SQLException e) {
+            connection.close();
+            throw e;
+        }
     }
 
 }

--- a/src/test/java/com/example/tests/BaseRestIntegrationTest.java
+++ b/src/test/java/com/example/tests/BaseRestIntegrationTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,7 +18,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 
 @Slf4j
 @ExtendWith(RestDocumentationExtension.class)
-@AutoConfigureTestRestTemplate
 public abstract class BaseRestIntegrationTest extends BaseIntegrationTest {
 
     protected final TestRestTemplate restAnonymousTemplate;


### PR DESCRIPTION
## Decision and separation

**ACCEPT PERFORMANCE** for the exact measured stack assembled from accepted children #1132, #1133, #1134, #1135, and #1137 on top of neutral foundation #1148/#1136.

This PR preserves the foundation/performance separation. The final-delivery stage runs no timing cohort and adds no new numerical performance claim.

Final delivery/readiness task: [019f5fff-52d1-7303-8778-0a2cc88e27d8](https://chatgpt.com/codex/tasks/019f5fff-52d1-7303-8778-0a2cc88e27d8).

## Recovery and exact stacked topology

Prior final PR #1144 is an inaccessible ghost object. This replacement uses permanent collision-free aliases at the exact original accepted commits; no commit was created or rewritten and neither original final branch was moved.

- Base alias: `codex/perf-campaign-foundation-1131-pr-recovery`
- Base: `c46b0562d43d9f0fc87bd853e2355c09e0fc4ae2`, tree `a176e23e3255a00fed109377118841010e0da8f7`
- Original performance branch: `codex/perf-campaign-performance-1131`
- PR head alias: `codex/perf-campaign-performance-1131-pr-recovery`
- Head: `2f79e1c570a6c0ca93537fe9296488be75b634be`, tree `36645bbd981c10156973fc860aab6fc94ec6d340`
- Ordered head parents: old repaired performance `ea1942c9a8c10f4fc6c2efd171a27be947a9e2d3`, then final repaired foundation `c46b0562d43d9f0fc87bd853e2355c09e0fc4ae2`
- Foundation-to-performance diff: 7 files, 428 insertions, 25 deletions
- Performance patch ID in both accepted directions: `8c32859a7af98306c3a24bf32a93198535d1d50f`
- `git merge-tree --write-tree ea1942c9 c46b0562` reproduces the exact head tree

Included: accepted #1132 context sharing, the accepted four-change #1135 runtime-classpath subset, corrected #1133 prepared JoinFaces metadata, developer-only/CI-fail-closed #1137 reuse, and corrected #1134 Java 25 AOT cache. Excluded: #1135 Gson removal (functional JSF regression), canonical test AOT/test metadata and broader AOT (#1133), and any #1136 performance claim (inconclusive/no claim).

## Frozen combined measurements

Original baseline `580ac7033684039ea537a068a004fe6b6ea628b6` versus accepted final stack, four accepted samples per variant per primary cohort:

- Packaged process-to-ready: `17125 ms [15537,18752] -> 11357.5 ms [10803,12885]`, **-33.68%**
- Docker process-to-ready: `13143.6165 ms [12945.897,13725.845] -> 5616.759 ms [5512.545,5880.53]`, **-57.27%**
- Integration Gradle wall: `74743.5 ms [71249,77916] -> 64697 ms [63817,65265]`, **-13.44%**

Every final primary startup/wall sample beat every baseline sample. These are retained campaign measurements, not PR-recovery results.

## Exact-head validation, hosted CI, and review

- Java 25 clean Gradle gate: `BUILD SUCCESSFUL in 2m 7s`; 65/65 tests; Selenium container 8/8; REST 7/7; profiling 2/2
- JaCoCo 328/328; all four retained filters zero-missed; REST Docs, frontend, plain/boot archives, Spotless, PMD, and SpotBugs passed
- Compatibility: 8 fresh rows / 8 carried by exact equivalence / 2 reduced coverage / 0 pending affected / 0 unvalidated affected
- Post-isolation adversarial rereview: [COMPLETE / ACCEPT FOUNDATION/NEUTRAL](https://chatgpt.com/codex/tasks/019f5f7f-1621-7081-b964-021df37b1fa4), zero actionable findings
- Exact-performance probe: temporary draft #1150, run [29321114229](https://github.com/kamkie/demo-spring-jsf/actions/runs/29321114229), attempt 1, terminal success in 352.15 s; 65/65 tests; 328/328 lines; zero reruns
- Tested merge `fa91ae72552d1647cbdc066b35be6f21ad3bf4a7`, ordered parents current `master` `90cf16625fad73fde1a80247cfd75a199d1cfd3d` then exact performance `2f79e1c570a6c0ca93537fe9296488be75b634be`
- Eight green same-head contexts: `build`, `Test Results`, `PMD`, `spotbugs`, `CodeQL`, `Trivy`, `codecov/project`, `codecov/patch`
- #1150 is closed, still draft, unmerged, no auto-merge; its temporary branch is deleted
- Current-head reviews: zero; review threads: zero; current-head `CHANGES_REQUESTED`: zero

Important hosted-CI limitation: #1149 displays the same-head commit contexts produced by #1150. It did **not** execute a separate workflow against its stacked base. The accepted hosted gate is the exact `2f79e1c` master-based probe described above; this body does not represent it as a distinct stacked-base run.

## NO_RERUN, costs, and limitations

The logger-isolation repair remains `NO_RERUN`. Packaged and Docker cohorts execute neither changed test. `RestIntegrationTest` is selected in integration-wall while `ProfilingProfileIntegrationTest` is not; `homeLogging()` therefore adds one proven-uncontended resource-lock acquisition. Exact selected-test-object equivalence is explicitly not claimed.

- Combined final Docker image is 16.38% larger and requires 58.728 s of final training/build setup. Exact arithmetic is 16.3809277509%; the displayed 16.38% is unchanged.
- Packaged first-admin median is about 5.9 ms slower; integration first-Selenium median is 5.23% slower with overlapping ranges.
- #1133 raises clean-build cost; cache restoration avoids most repeated cost.
- #1134 retains image/build/memory/steady-request costs; AOT cache is functionally reproducible but not byte-identical.
- #1137 reuse remains developer-only, explicit opt-in, and CI-fail-closed; it is not counted in the default cohort.
- Evidence is local Windows/Docker Desktop with n=4 and observed ranges. Literal hosted-Linux Selenium routing remains reduced coverage.
- The old #1144 object remains inaccessible; this recovery PR is canonical delivery.
- This task may mark readiness only after an immediate exact stacked-base/head/master/ref/check/review/thread re-fetch. It may not merge or enable auto-merge.

Recommended merge order: **#1148 first, then #1149**. Do not merge #1149 first.

Durable evidence roots:

- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\integration-performance`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\combined-validation`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\performance-logger-isolation-refresh`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\post-isolation-final-revalidation`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\post-isolation-adversarial-rereview`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\hosted-ci-final-retry`
- `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\final-delivery-readiness`
