### PR TITLE
[CI probe] exact performance head 2f79e1c

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 **
 !build/libs
+!scripts/aot-train.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache postgresql18=18.4-r0
 COPY --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --from=builder /app/extracted/dependencies/ ./
 COPY --from=builder /app/extracted/application/ ./
-COPY scripts/aot-train.sh /usr/local/bin/aot-train
+COPY --chmod=0755 scripts/aot-train.sh /usr/local/bin/aot-train
 
 ENV SPRING_PROFILES_ACTIVE=deployed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:25 AS base
+FROM azul/zulu-openjdk-alpine:25@sha256:a772cce2bb079795bb02a3637275fbfa885893ca5014eb8c84e2e1c027aa48da AS base
 RUN addgroup -S spring && adduser -S spring -G spring
 RUN mkdir /app
 WORKDIR /app
@@ -8,15 +8,26 @@ ARG JAR_FILE=build/libs/demo-spring-jsf-*-boot.jar
 COPY ${JAR_FILE} app.jar
 RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted/
 
-FROM base AS runnable
+FROM base AS trainer
+
+RUN apk add --no-cache postgresql18=18.4-r0
 
 COPY --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --from=builder /app/extracted/dependencies/ ./
 COPY --from=builder /app/extracted/application/ ./
+COPY scripts/aot-train.sh /usr/local/bin/aot-train
+
+ENV SPRING_PROFILES_ACTIVE=deployed
+
+RUN /usr/local/bin/aot-train
+
+FROM base AS runnable
+
+COPY --from=trainer /app/ ./
 USER spring:spring
 
 ENV SPRING_PROFILES_ACTIVE=deployed
 
 RUN ls -lha
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-XX:AOTMode=on", "-XX:AOTCache=/app/application.aot", "-Xlog:aot=info", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY --from=builder /app/extracted/dependencies/ ./
 COPY --from=builder /app/extracted/application/ ./
 USER spring:spring
 
+ENV SPRING_PROFILES_ACTIVE=deployed
+
 RUN ls -lha
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ Spring Boot Aplication with Docker
 ```
 The Gradle build runs the frontend bundle step automatically.
 
+### Runtime profiles
+
+Runtime intent is explicit and does not use profile groups:
+
+- `./gradlew bootRun` activates `local-development`: Hibernate statistics, DEBUG web/SQL/timing logs, and the four
+  request context filters are enabled; JSF uses development stage.
+- Integration tests retain `@ActiveProfiles("test")`: statistics, JMX, verbose logging, and custom request filters are
+  disabled; JSF uses production stage.
+- The Docker image activates `deployed`: the same lean runtime defaults are explicit for deployed containers.
+- `--spring.profiles.active=profiling` opts into Hibernate statistics, JMX, Mojarra TRACE, verbose web/SQL logging, and
+  all four custom request filters.
+- Starting the executable JAR without a profile uses the lean defaults and is equivalent to the diagnostic settings of
+  `deployed`; select `deployed` explicitly for deployment automation outside the checked-in Docker image.
+
+All modes instantiate and expose only the required read-only Actuator endpoints: health, info, metrics, and Prometheus.
+Existing security rules remain responsible for HTTP authorization.
+
 Run the fast unit-only test loop without integration or Selenium tests:
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Runtime intent is explicit and does not use profile groups:
 - Starting the executable JAR without a profile uses the lean defaults and is equivalent to the diagnostic settings of
   `deployed`; select `deployed` explicitly for deployment automation outside the checked-in Docker image.
 
+Boot and plain archives precompute JoinFaces scan metadata with the fixed `deployed` profile. Tests do not consume this
+metadata; their `test` profile and test runtime classpath continue to be scanned independently.
+
 All modes instantiate and expose only the required read-only Actuator endpoints: health, info, metrics, and Prometheus.
 Existing security rules remain responsible for HTTP authorization.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ and VNC MP4 recording. When `host.testcontainers.internal` is unavailable in con
 On Windows, host mode keeps Chrome headed on a dedicated Windows desktop so a local Selenium run cannot activate over the
 current application. Non-Windows host runs and container mode keep their existing headed browser behavior.
 
+### Reusing the test database locally
+
+Repeated local test invocations can retain the project Testcontainers PostgreSQL instance. This is an experimental,
+developer-only opt-in and is always disabled when a CI environment variable is present. Enable both required flags in
+PowerShell:
+
+```powershell
+$env:TESTCONTAINERS_REUSE_ENABLE = 'true'
+.\gradlew.bat test -Ptestcontainers.reuse=true
+```
+
+On POSIX shells:
+
+```sh
+export TESTCONTAINERS_REUSE_ENABLE=true
+./gradlew test -Ptestcontainers.reuse=true
+```
+
+Each invocation takes an advisory lock for its full test JVM lifetime, removes and recreates the `public` schema, and
+then lets Liquibase rebuild schema and seed data. Do not use the retained database for application data. Disable reuse
+with `Remove-Item Env:TESTCONTAINERS_REUSE_ENABLE` (PowerShell) or `unset TESTCONTAINERS_REUSE_ENABLE` (POSIX), and omit
+the Gradle property. Remove only this project's retained containers with:
+
+```powershell
+docker ps -aq --filter "label=com.example.demo-spring-jsf.reusable-postgres=true" |
+    ForEach-Object { docker rm -f $_ }
+```
+
+```sh
+for container in $(docker ps -aq --filter "label=com.example.demo-spring-jsf.reusable-postgres=true"); do
+    docker rm -f "$container"
+done
+```
+
 ### Docker
 Install Docker.
 Run the Docker image, by executing the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,16 @@ import com.github.spotbugs.snom.SpotBugsTask
 import com.palantir.gradle.gitversion.CommonGitOperations
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.api.tasks.Sync
+import org.gradle.jvm.tasks.Jar
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
+import org.springframework.boot.gradle.tasks.aot.ProcessAot
+import org.springframework.boot.gradle.tasks.bundling.BootJar
 import org.springframework.boot.gradle.util.VersionExtractor
 import java.io.Serializable
 import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
+import java.util.zip.ZipFile
 
 buildscript {
     repositories {
@@ -276,6 +281,38 @@ tasks.bootRun {
     }
 }
 
+val joinFacesMetadataProfile = "deployed"
+val generateJoinFacesMetadata = tasks.register<ProcessAot>("generateJoinFacesMetadata") {
+    group = "build"
+    description = "Generates JoinFaces scan metadata from Spring AOT processors."
+    dependsOn(tasks.named("classes"))
+    applicationMainClass.set("com.example.DemoApplication")
+    sourcesOutput.set(layout.buildDirectory.dir("generated/joinFacesAot/sources"))
+    resourcesOutput.set(layout.buildDirectory.dir("generated/joinFacesAot/resources"))
+    classesOutput.set(layout.buildDirectory.dir("generated/joinFacesAot/classes"))
+    groupId.set(project.group.toString())
+    artifactId.set(project.name)
+    classpath = files(sourceSets.main.get().output, configurations.named("productionRuntimeClasspath"))
+    args("--spring.profiles.active=$joinFacesMetadataProfile")
+}
+
+val generatedJoinFacesMetadata = generateJoinFacesMetadata
+    .flatMap(ProcessAot::getResourcesOutput)
+    .map { it.dir("META-INF/joinfaces") }
+val preparedJoinFacesMetadata = layout.buildDirectory.dir("generated/joinFacesMetadata")
+val prepareJoinFacesMetadata = tasks.register<Sync>("prepareJoinFacesMetadata") {
+    dependsOn(generateJoinFacesMetadata)
+    from(generatedJoinFacesMetadata)
+    into(preparedJoinFacesMetadata)
+    outputs.cacheIf("Prepared metadata is fully declared and normalized") { true }
+    doLast {
+        preparedJoinFacesMetadata.get().asFile.listFiles()?.filter { it.isFile }?.forEach { file ->
+            val sortedLines = file.readLines(StandardCharsets.UTF_8).sorted()
+            file.writeText(if (sortedLines.isEmpty()) "" else sortedLines.joinToString("\n", postfix = "\n"), StandardCharsets.UTF_8)
+        }
+    }
+}
+
 val asciidoctorTask = tasks.register<JavaExec>("asciidoctor") {
     group = "documentation"
     description = "Generates the Spring REST Docs reference documentation."
@@ -310,12 +347,104 @@ val asciidoctorTask = tasks.register<JavaExec>("asciidoctor") {
 
 tasks.bootJar {
     archiveClassifier.set("boot")
+    dependsOn(prepareJoinFacesMetadata)
+    from(preparedJoinFacesMetadata) {
+        into("BOOT-INF/classes/META-INF/joinfaces")
+    }
     from(asciidoctorTask) {
         into("BOOT-INF/classes/static/docs")
     }
     layered {
         enabled.set(true)
     }
+}
+
+tasks.jar {
+    dependsOn(prepareJoinFacesMetadata)
+    from(preparedJoinFacesMetadata) {
+        into("META-INF/joinfaces")
+    }
+}
+
+val verifyJoinFacesMetadata = tasks.register("verifyJoinFacesMetadata") {
+    group = "verification"
+    description = "Verifies generated and packaged JoinFaces scan metadata."
+    val expectedFiles = listOf(
+            "com.sun.faces.config.FacesInitializer.classes",
+            "com.sun.faces.config.FacesInitializer2.classes",
+            "com.sun.faces.spi.AnnotationProvider.classes",
+    )
+    val plainJar = tasks.named<Jar>("jar").flatMap(Jar::getArchiveFile)
+    val bootJar = tasks.named<BootJar>("bootJar").flatMap(BootJar::getArchiveFile)
+    dependsOn(prepareJoinFacesMetadata, plainJar, bootJar)
+    inputs.dir(preparedJoinFacesMetadata)
+    inputs.files(plainJar, bootJar)
+    inputs.property("profile", joinFacesMetadataProfile)
+
+    doLast {
+        check(joinFacesMetadataProfile == "deployed") {
+            "JoinFaces runtime metadata must be generated with the deployed profile"
+        }
+        val metadataDirectory = preparedJoinFacesMetadata.get().asFile
+        val actualFiles = metadataDirectory.walkTopDown()
+            .filter { it.isFile }
+            .map { it.relativeTo(metadataDirectory).invariantSeparatorsPath }
+            .toList()
+        check(actualFiles.sorted() == expectedFiles.sorted()) {
+            "Expected exactly $expectedFiles but found $actualFiles"
+        }
+        val archives = listOf(
+                plainJar.get().asFile to "META-INF/joinfaces/",
+                bootJar.get().asFile to "BOOT-INF/classes/META-INF/joinfaces/",
+        )
+        archives.forEach { (archive, prefix) ->
+            ZipFile(archive).use { zip ->
+                val packagedFiles = zip.entries().asSequence()
+                    .filter { !it.isDirectory && it.name.startsWith(prefix) }
+                    .map { it.name.removePrefix(prefix) }
+                    .toList()
+                check(packagedFiles.sorted() == expectedFiles.sorted()) {
+                    "Expected exactly $expectedFiles under $prefix in ${archive.name}, found $packagedFiles"
+                }
+            }
+        }
+
+        expectedFiles.forEach { fileName ->
+            val generatedFile = metadataDirectory.resolve(fileName)
+            val lines = generatedFile.readLines(StandardCharsets.UTF_8)
+            when (fileName) {
+                "com.sun.faces.config.FacesInitializer.classes" -> {
+                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
+                    check(lines == lines.sorted().distinct()) { "$fileName must be sorted and contain no duplicates" }
+                }
+                "com.sun.faces.config.FacesInitializer2.classes" ->
+                    check(lines.isEmpty()) { "$fileName is expected to be an empty prepared result" }
+                "com.sun.faces.spi.AnnotationProvider.classes" -> {
+                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
+                    val keys = lines.map { it.substringBefore('=', missingDelimiterValue = "") }
+                    check(keys.none(String::isBlank) && keys.distinct().size == keys.size) {
+                        "$fileName must contain unique annotation keys"
+                    }
+                }
+            }
+
+            archives.forEach { (archive, prefix) ->
+                val entryName = "$prefix$fileName"
+                ZipFile(archive).use { zip ->
+                    val entries = zip.entries().asSequence().filter { it.name == entryName }.toList()
+                    check(entries.size == 1) { "Expected one $entryName in ${archive.name}, found ${entries.size}" }
+                    val packagedBytes = zip.getInputStream(entries.single()).use { it.readAllBytes() }
+                    check(packagedBytes.contentEquals(generatedFile.readBytes())) {
+                        "$entryName in ${archive.name} is stale or incomplete"
+                    }
+                }
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(verifyJoinFacesMetadata)
 }
 
 tasks.jacocoTestReport {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,24 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.github.gradle.node.task.NodeTask
 import com.github.spotbugs.snom.SpotBugsTask
 import com.palantir.gradle.gitversion.CommonGitOperations
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.gradle.api.tasks.Sync
 import org.gradle.jvm.tasks.Jar
+import org.gradle.work.DisableCachingByDefault
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.aot.ProcessAot
 import org.springframework.boot.gradle.tasks.bundling.BootJar
@@ -15,6 +29,130 @@ import java.io.Serializable
 import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 import java.util.zip.ZipFile
+import javax.inject.Inject
+
+@CacheableTask
+abstract class PrepareJoinFacesMetadata : DefaultTask() {
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceDirectory: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val destinationDirectory: DirectoryProperty
+
+    @get:Inject
+    abstract val fileSystemOperations: FileSystemOperations
+
+    @TaskAction
+    fun prepare() {
+        val source = sourceDirectory.get().asFile
+        val destination = destinationDirectory.get().asFile
+        fileSystemOperations.delete { delete(destination) }
+        fileSystemOperations.copy {
+            from(source)
+            into(destination)
+        }
+        destination.listFiles()?.filter { it.isFile }?.forEach { file ->
+            val sortedLines = file.readLines(StandardCharsets.UTF_8).sorted()
+            file.writeText(
+                    if (sortedLines.isEmpty()) "" else sortedLines.joinToString("\n", postfix = "\n"),
+                    StandardCharsets.UTF_8,
+            )
+        }
+    }
+}
+
+@DisableCachingByDefault(because = "Verification task has no outputs")
+abstract class VerifyJoinFacesMetadata : DefaultTask() {
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val metadataDirectory: DirectoryProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val plainArchive: RegularFileProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val bootArchive: RegularFileProperty
+
+    @get:Input
+    abstract val profile: Property<String>
+
+    @get:Input
+    abstract val expectedFiles: ListProperty<String>
+
+    @get:Input
+    abstract val plainPrefix: Property<String>
+
+    @get:Input
+    abstract val bootPrefix: Property<String>
+
+    @TaskAction
+    fun verify() {
+        check(profile.get() == "deployed") {
+            "JoinFaces runtime metadata must be generated with the deployed profile"
+        }
+        val expected = expectedFiles.get()
+        val metadata = metadataDirectory.get().asFile
+        val actualFiles = metadata.walkTopDown()
+            .filter { it.isFile }
+            .map { it.relativeTo(metadata).invariantSeparatorsPath }
+            .toList()
+        check(actualFiles.sorted() == expected.sorted()) {
+            "Expected exactly $expected but found $actualFiles"
+        }
+        val archives = listOf(
+                plainArchive.get().asFile to plainPrefix.get(),
+                bootArchive.get().asFile to bootPrefix.get(),
+        )
+        archives.forEach { (archive, prefix) ->
+            ZipFile(archive).use { zip ->
+                val packagedFiles = zip.entries().asSequence()
+                    .filter { !it.isDirectory && it.name.startsWith(prefix) }
+                    .map { it.name.removePrefix(prefix) }
+                    .toList()
+                check(packagedFiles.sorted() == expected.sorted()) {
+                    "Expected exactly $expected under $prefix in ${archive.name}, found $packagedFiles"
+                }
+            }
+        }
+
+        expected.forEach { fileName ->
+            val generatedFile = metadata.resolve(fileName)
+            val lines = generatedFile.readLines(StandardCharsets.UTF_8)
+            when (fileName) {
+                "com.sun.faces.config.FacesInitializer.classes" -> {
+                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
+                    check(lines == lines.sorted().distinct()) { "$fileName must be sorted and contain no duplicates" }
+                }
+                "com.sun.faces.config.FacesInitializer2.classes" ->
+                    check(lines.isEmpty()) { "$fileName is expected to be an empty prepared result" }
+                "com.sun.faces.spi.AnnotationProvider.classes" -> {
+                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
+                    val keys = lines.map { it.substringBefore('=', missingDelimiterValue = "") }
+                    check(keys.none(String::isBlank) && keys.distinct().size == keys.size) {
+                        "$fileName must contain unique annotation keys"
+                    }
+                }
+            }
+
+            archives.forEach { (archive, prefix) ->
+                val entryName = "$prefix$fileName"
+                ZipFile(archive).use { zip ->
+                    val entries = zip.entries().asSequence().filter { it.name == entryName }.toList()
+                    check(entries.size == 1) { "Expected one $entryName in ${archive.name}, found ${entries.size}" }
+                    val packagedBytes = zip.getInputStream(entries.single()).use { it.readAllBytes() }
+                    check(packagedBytes.contentEquals(generatedFile.readBytes())) {
+                        "$entryName in ${archive.name} is stale or incomplete"
+                    }
+                }
+            }
+        }
+    }
+}
 
 buildscript {
     repositories {
@@ -300,17 +438,12 @@ val generatedJoinFacesMetadata = generateJoinFacesMetadata
     .flatMap(ProcessAot::getResourcesOutput)
     .map { it.dir("META-INF/joinfaces") }
 val preparedJoinFacesMetadata = layout.buildDirectory.dir("generated/joinFacesMetadata")
-val prepareJoinFacesMetadata = tasks.register<Sync>("prepareJoinFacesMetadata") {
+val prepareJoinFacesMetadata = tasks.register<PrepareJoinFacesMetadata>("prepareJoinFacesMetadata") {
+    group = "build"
+    description = "Prepares deterministic JoinFaces scan metadata for packaging."
     dependsOn(generateJoinFacesMetadata)
-    from(generatedJoinFacesMetadata)
-    into(preparedJoinFacesMetadata)
-    outputs.cacheIf("Prepared metadata is fully declared and normalized") { true }
-    doLast {
-        preparedJoinFacesMetadata.get().asFile.listFiles()?.filter { it.isFile }?.forEach { file ->
-            val sortedLines = file.readLines(StandardCharsets.UTF_8).sorted()
-            file.writeText(if (sortedLines.isEmpty()) "" else sortedLines.joinToString("\n", postfix = "\n"), StandardCharsets.UTF_8)
-        }
-    }
+    sourceDirectory.set(generatedJoinFacesMetadata)
+    destinationDirectory.set(preparedJoinFacesMetadata)
 }
 
 val asciidoctorTask = tasks.register<JavaExec>("asciidoctor") {
@@ -366,81 +499,23 @@ tasks.jar {
     }
 }
 
-val verifyJoinFacesMetadata = tasks.register("verifyJoinFacesMetadata") {
+val verifyJoinFacesMetadata = tasks.register<VerifyJoinFacesMetadata>("verifyJoinFacesMetadata") {
     group = "verification"
     description = "Verifies generated and packaged JoinFaces scan metadata."
-    val expectedFiles = listOf(
+    expectedFiles.set(listOf(
             "com.sun.faces.config.FacesInitializer.classes",
             "com.sun.faces.config.FacesInitializer2.classes",
             "com.sun.faces.spi.AnnotationProvider.classes",
-    )
-    val plainJar = tasks.named<Jar>("jar").flatMap(Jar::getArchiveFile)
-    val bootJar = tasks.named<BootJar>("bootJar").flatMap(BootJar::getArchiveFile)
-    dependsOn(prepareJoinFacesMetadata, plainJar, bootJar)
-    inputs.dir(preparedJoinFacesMetadata)
-    inputs.files(plainJar, bootJar)
-    inputs.property("profile", joinFacesMetadataProfile)
-
-    doLast {
-        check(joinFacesMetadataProfile == "deployed") {
-            "JoinFaces runtime metadata must be generated with the deployed profile"
-        }
-        val metadataDirectory = preparedJoinFacesMetadata.get().asFile
-        val actualFiles = metadataDirectory.walkTopDown()
-            .filter { it.isFile }
-            .map { it.relativeTo(metadataDirectory).invariantSeparatorsPath }
-            .toList()
-        check(actualFiles.sorted() == expectedFiles.sorted()) {
-            "Expected exactly $expectedFiles but found $actualFiles"
-        }
-        val archives = listOf(
-                plainJar.get().asFile to "META-INF/joinfaces/",
-                bootJar.get().asFile to "BOOT-INF/classes/META-INF/joinfaces/",
-        )
-        archives.forEach { (archive, prefix) ->
-            ZipFile(archive).use { zip ->
-                val packagedFiles = zip.entries().asSequence()
-                    .filter { !it.isDirectory && it.name.startsWith(prefix) }
-                    .map { it.name.removePrefix(prefix) }
-                    .toList()
-                check(packagedFiles.sorted() == expectedFiles.sorted()) {
-                    "Expected exactly $expectedFiles under $prefix in ${archive.name}, found $packagedFiles"
-                }
-            }
-        }
-
-        expectedFiles.forEach { fileName ->
-            val generatedFile = metadataDirectory.resolve(fileName)
-            val lines = generatedFile.readLines(StandardCharsets.UTF_8)
-            when (fileName) {
-                "com.sun.faces.config.FacesInitializer.classes" -> {
-                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
-                    check(lines == lines.sorted().distinct()) { "$fileName must be sorted and contain no duplicates" }
-                }
-                "com.sun.faces.config.FacesInitializer2.classes" ->
-                    check(lines.isEmpty()) { "$fileName is expected to be an empty prepared result" }
-                "com.sun.faces.spi.AnnotationProvider.classes" -> {
-                    check(lines.isNotEmpty()) { "$fileName must not be empty" }
-                    val keys = lines.map { it.substringBefore('=', missingDelimiterValue = "") }
-                    check(keys.none(String::isBlank) && keys.distinct().size == keys.size) {
-                        "$fileName must contain unique annotation keys"
-                    }
-                }
-            }
-
-            archives.forEach { (archive, prefix) ->
-                val entryName = "$prefix$fileName"
-                ZipFile(archive).use { zip ->
-                    val entries = zip.entries().asSequence().filter { it.name == entryName }.toList()
-                    check(entries.size == 1) { "Expected one $entryName in ${archive.name}, found ${entries.size}" }
-                    val packagedBytes = zip.getInputStream(entries.single()).use { it.readAllBytes() }
-                    check(packagedBytes.contentEquals(generatedFile.readBytes())) {
-                        "$entryName in ${archive.name} is stale or incomplete"
-                    }
-                }
-            }
-        }
-    }
+    ))
+    val plainJarTask = tasks.named<Jar>("jar")
+    val bootJarTask = tasks.named<BootJar>("bootJar")
+    dependsOn(prepareJoinFacesMetadata, plainJarTask, bootJarTask)
+    metadataDirectory.set(preparedJoinFacesMetadata)
+    plainArchive.set(plainJarTask.flatMap(Jar::getArchiveFile))
+    bootArchive.set(bootJarTask.flatMap(BootJar::getArchiveFile))
+    profile.set(joinFacesMetadataProfile)
+    plainPrefix.set("META-INF/joinfaces/")
+    bootPrefix.set("BOOT-INF/classes/META-INF/joinfaces/")
 }
 
 tasks.check {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,6 @@ val jnaVersion = "5.19.1"
 val seleniumVersion = "4.46.0"
 val asciiDoctorJVersion = "3.0.1"
 val picocliVersion = "4.7.7"
-val spotbugsAnnotationsVersion = "4.10.3"
 val logstashLogbackEncoderVersion = "9.0"
 val joinfacesVersion = "6.1.0"
 val primefacesThemesVersion = "1.1.0"
@@ -94,6 +93,9 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     annotationProcessor("org.springframework:spring-context-indexer")
 
+    compileOnly("org.projectlombok:lombok")
+    testCompileOnly("org.projectlombok:lombok")
+
     asciidoctorRuntime("org.asciidoctor:asciidoctorj:$asciiDoctorJVersion")
     asciidoctorRuntime("org.asciidoctor:asciidoctorj-cli:$asciiDoctorJVersion")
     asciidoctorRuntime("org.springframework.restdocs:spring-restdocs-asciidoctor")
@@ -104,10 +106,6 @@ dependencies {
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 
-    implementation("com.github.spotbugs:spotbugs-annotations:$spotbugsAnnotationsVersion")
-    implementation("org.projectlombok:lombok")
-
-    implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-aspectj")
     implementation("org.springframework.boot:spring-boot-starter-cache")
@@ -115,7 +113,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.boot:spring-boot-restclient")
     implementation("org.springframework.boot:spring-boot-session")
     implementation("org.springframework.session:spring-session-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
@@ -134,6 +131,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    testImplementation("org.springframework.boot:spring-boot-restclient")
     testImplementation("org.springframework.boot:spring-boot-resttestclient")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
     testImplementation("org.springframework.boot:spring-boot-starter-session-jdbc-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,6 +262,7 @@ tasks.withType<JavaCompile> {
 
 tasks.bootRun {
     systemProperty("spring.output.ansi.enabled", "always")
+    systemProperty("spring.profiles.active", providers.systemProperty("spring.profiles.active").getOrElse("local-development"))
     jvmArgs = listOf(
             "--add-opens=java.base/java.lang=ALL-UNNAMED",
             "--add-opens=java.base/java.math=ALL-UNNAMED",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -540,6 +540,13 @@ tasks.withType<Test> {
         .orElse(providers.environmentVariable("SELENIUM_MODE"))
         .orNull
         ?.let { systemProperty("selenium.mode", it) }
+    val ciEnvironment = listOf("CI", "GITHUB_ACTIONS", "JENKINS_URL", "BUILD_NUMBER")
+        .any { providers.environmentVariable(it).isPresent }
+    val reuseRequested = providers.gradleProperty("testcontainers.reuse")
+        .orElse(providers.systemProperty("testcontainers.reuse"))
+        .map(String::toBoolean)
+        .getOrElse(false)
+    systemProperty("testcontainers.reuse", reuseRequested && !ciEnvironment)
     jvmArgs = listOf(
             "-XX:+EnableDynamicAgentLoading",
             "--enable-native-access=ALL-UNNAMED",

--- a/scripts/aot-train.sh
+++ b/scripts/aot-train.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+set -eu
+
+postgres_data=/tmp/postgresql
+postgres_socket=/tmp/postgresql-socket
+postgres_started=false
+application_pid=
+
+cleanup() {
+    if [ -n "$application_pid" ] && kill -0 "$application_pid" 2>/dev/null; then
+        kill -TERM "$application_pid"
+        wait "$application_pid" || true
+    fi
+    if [ "$postgres_started" = true ]; then
+        su postgres -s /bin/sh -c "pg_ctl -D '$postgres_data' -m fast -w stop" >/dev/null
+    fi
+}
+trap cleanup EXIT INT TERM
+
+install -d -o postgres -g postgres "$postgres_data" "$postgres_socket"
+printf 'dev\n' >/tmp/postgresql-password
+chown postgres:postgres /tmp/postgresql-password
+chmod 600 /tmp/postgresql-password
+su postgres -s /bin/sh -c \
+    "initdb -D '$postgres_data' --username=dev --pwfile=/tmp/postgresql-password --auth-local=trust --auth-host=scram-sha-256" \
+    >/dev/null
+su postgres -s /bin/sh -c \
+    "pg_ctl -D '$postgres_data' -o '-h 127.0.0.1 -k $postgres_socket -p 5432' -w start" \
+    >/dev/null
+postgres_started=true
+su postgres -s /bin/sh -c "createdb -h '$postgres_socket' -p 5432 -U dev spring-demo"
+
+export SPRING_DATASOURCE_URL=jdbc:postgresql://127.0.0.1:5432/spring-demo
+export SPRING_DATASOURCE_USERNAME=dev
+export SPRING_DATASOURCE_PASSWORD=dev
+su spring -s /bin/sh -c \
+    'exec java -XX:AOTCacheOutput=/tmp/application.aot -Xlog:aot=info -jar app.jar' &
+application_pid=$!
+
+attempt=0
+until wget -q -T 2 -O /dev/null http://127.0.0.1:8080/actuator/health; do
+    if ! kill -0 "$application_pid" 2>/dev/null; then
+        wait "$application_pid"
+    fi
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 900 ]; then
+        echo 'Application did not become ready during AOT training.' >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+
+for path in / /admin /table.xhtml; do
+    wget -q -T 10 -O /dev/null "http://127.0.0.1:8080$path"
+done
+
+kill -TERM "$application_pid"
+set +e
+wait "$application_pid"
+application_status=$?
+set -e
+application_pid=
+if [ "$application_status" -ne 0 ] && [ "$application_status" -ne 143 ]; then
+    echo "AOT training application exited with status $application_status." >&2
+    exit "$application_status"
+fi
+if [ ! -s /tmp/application.aot ]; then
+    echo 'AOT training did not produce /tmp/application.aot.' >&2
+    exit 1
+fi
+install -o root -g root -m 0444 /tmp/application.aot /app/application.aot

--- a/src/main/resources/application-deployed.yaml
+++ b/src/main/resources/application-deployed.yaml
@@ -1,0 +1,22 @@
+spring:
+  jmx:
+    enabled: false
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: false
+
+joinfaces:
+  faces:
+    project-stage: production
+
+logging:
+  custom:
+    time:
+      enable: false
+    user:
+      enable: false
+    session:
+      enable: false
+    request:
+      enable: false

--- a/src/main/resources/application-local-development.yaml
+++ b/src/main/resources/application-local-development.yaml
@@ -1,0 +1,28 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+
+joinfaces:
+  faces:
+    project-stage: development
+
+logging:
+  level:
+    web: DEBUG
+    org:
+      springframework.web:
+        filter: debug
+      hibernate:
+        SQL: debug
+        stat: debug
+  custom:
+    time:
+      enable: true
+    user:
+      enable: true
+    session:
+      enable: true
+    request:
+      enable: true

--- a/src/main/resources/application-profiling.yaml
+++ b/src/main/resources/application-profiling.yaml
@@ -1,0 +1,35 @@
+spring:
+  jmx:
+    enabled: true
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+
+joinfaces:
+  faces:
+    project-stage: development
+
+logging:
+  level:
+    web: DEBUG
+    org:
+      springframework.web:
+        filter: debug
+      hibernate:
+        SQL: debug
+        stat: debug
+    com:
+      sun:
+        faces: trace
+    javax:
+      faces: trace
+  custom:
+    time:
+      enable: true
+    user:
+      enable: true
+    session:
+      enable: true
+    request:
+      enable: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ spring:
     show-sql: false
     properties:
       hibernate:
-        generate_statistics: true
+        generate_statistics: false
     open-in-view: false
 
   datasource:
@@ -22,7 +22,7 @@ spring:
     enabled: true
   #    drop-first: true
   jmx:
-    enabled: true
+    enabled: false
 
   cache:
     cache-names:
@@ -48,7 +48,7 @@ joinfaces:
   primefaces:
     theme: bootstrap
   faces:
-    project-stage: development
+    project-stage: production
     serialize-server-state: true
 
 server:
@@ -68,11 +68,20 @@ management:
       mode: full
   endpoint:
     health:
+      access: read-only
       show-details: when_authorized
+    info:
+      access: read-only
+    metrics:
+      access: read-only
+    prometheus:
+      access: read-only
   endpoints:
+    access:
+      default: none
     web:
       exposure:
-        include: '*'
+        include: health,info,metrics,prometheus
   metrics:
     web:
       server:
@@ -90,17 +99,17 @@ logging:
     console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} [rid=%X{rid} sid=%X{sid} \
 user=%X{userName}] %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
   level:
-    web: DEBUG
+    web: INFO
     org:
       apache.tomcat.util.scan.StandardJarScanner: error
       springframework.web:
-        filter: debug
+        filter: info
       #        servlet.DispatcherServlet: debug
       hibernate:
         engine: warn #info to show session times
         type: info #trace to show binding parameters
-        SQL: debug #debug to show generated sql
-        stat: debug #debug to show hql query times
+        SQL: info #debug to show generated sql
+        stat: info #debug to show hql query times
     com:
       sun:
         faces: info
@@ -113,13 +122,13 @@ user=%X{userName}] %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39
       faces: info
   custom:
     time:
-      enable: true
+      enable: false
     user:
-      enable: true
+      enable: false
     session:
-      enable: true
+      enable: false
     request:
-      enable: true
+      enable: false
 
 #logbook:
 #    exclude:

--- a/src/test/java/com/example/extension/DockerExtension.java
+++ b/src/test/java/com/example/extension/DockerExtension.java
@@ -3,7 +3,12 @@ package com.example.extension;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.Extension;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -11,26 +16,96 @@ import java.util.concurrent.locks.ReentrantLock;
 @SuppressWarnings("PMD.DoNotUseThreads")
 public class DockerExtension implements Extension {
 
-    private static final PostgreSQLContainer POSTGRES_SQL_CONTAINER = new PostgreSQLContainer("postgres:17.10");
+    private static final String REUSE_PROPERTY = "testcontainers.reuse";
+    private static final String REUSE_LABEL = "com.example.demo-spring-jsf.reusable-postgres";
+    private static final long REUSE_LOCK_ID = 1_137L;
+    private static final boolean REUSE_ENABLED = reuseEnabled();
+    private static final PostgreSQLContainer POSTGRES_SQL_CONTAINER = postgresContainer();
     private static final Lock LOCK = new ReentrantLock();
+    private static Connection reuseLockConnection;
 
     public static PostgreSQLContainer getPostgres() {
-        if (!POSTGRES_SQL_CONTAINER.isRunning()) {
-            LOCK.lock();
-            try {
-                if (!POSTGRES_SQL_CONTAINER.isRunning()) {
-                    log.info("starting postgres container");
-                    POSTGRES_SQL_CONTAINER.start();
-                    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                        log.info("stopping postgres container");
-                        POSTGRES_SQL_CONTAINER.stop();
-                    }));
-                }
-            } finally {
-                LOCK.unlock();
+        if (POSTGRES_SQL_CONTAINER.isRunning()) {
+            return POSTGRES_SQL_CONTAINER;
+        }
+        LOCK.lock();
+        try {
+            if (POSTGRES_SQL_CONTAINER.isRunning()) {
+                return POSTGRES_SQL_CONTAINER;
             }
+            log.info("starting postgres container");
+            POSTGRES_SQL_CONTAINER.start();
+            if (REUSE_ENABLED) {
+                resetReusableDatabase();
+            } else {
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    log.info("stopping postgres container");
+                    POSTGRES_SQL_CONTAINER.stop();
+                }));
+            }
+        } finally {
+            LOCK.unlock();
         }
         return POSTGRES_SQL_CONTAINER;
+    }
+
+    private static boolean reuseEnabled() {
+        if (!Boolean.getBoolean(REUSE_PROPERTY) || isCi()) {
+            return false;
+        }
+        if (!TestcontainersConfiguration.getInstance().environmentSupportsReuse()) {
+            throw new IllegalStateException(
+                    "Reusable PostgreSQL requires TESTCONTAINERS_REUSE_ENABLE=true in addition to -D"
+                            + REUSE_PROPERTY + "=true"
+            );
+        }
+        return true;
+    }
+
+    private static PostgreSQLContainer postgresContainer() {
+        PostgreSQLContainer container = new PostgreSQLContainer("postgres:17.10");
+        if (REUSE_ENABLED) {
+            container.withLabel(REUSE_LABEL, "true").withReuse(true);
+        }
+        return container;
+    }
+
+    private static boolean isCi() {
+        return System.getenv("CI") != null
+                || System.getenv("GITHUB_ACTIONS") != null
+                || System.getenv("JENKINS_URL") != null
+                || System.getenv("BUILD_NUMBER") != null;
+    }
+
+    private static void resetReusableDatabase() {
+        try {
+            reuseLockConnection = openResetConnection();
+            log.info("reset reusable postgres schema and retained advisory lock {} for this test JVM", REUSE_LOCK_ID);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Could not reset reusable PostgreSQL before Spring startup", e);
+        }
+    }
+
+    private static Connection openResetConnection() throws SQLException {
+        Connection connection = DriverManager.getConnection(
+                POSTGRES_SQL_CONTAINER.getJdbcUrl(),
+                POSTGRES_SQL_CONTAINER.getUsername(),
+                POSTGRES_SQL_CONTAINER.getPassword()
+        );
+        try {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SET lock_timeout = '120s'");
+                statement.execute("SELECT pg_advisory_lock(" + REUSE_LOCK_ID + ")");
+                statement.execute("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                        + "WHERE datname = current_database() AND pid <> pg_backend_pid()");
+                statement.execute("DROP SCHEMA IF EXISTS public CASCADE");
+                statement.execute("CREATE SCHEMA public");
+            }
+            return connection;
+        } catch (SQLException e) {
+            connection.close();
+            throw e;
+        }
     }
 
 }

--- a/src/test/java/com/example/tests/BaseRestIntegrationTest.java
+++ b/src/test/java/com/example/tests/BaseRestIntegrationTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,7 +18,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 
 @Slf4j
 @ExtendWith(RestDocumentationExtension.class)
-@AutoConfigureTestRestTemplate
 public abstract class BaseRestIntegrationTest extends BaseIntegrationTest {
 
     protected final TestRestTemplate restAnonymousTemplate;

--- a/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
+++ b/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.example.tests;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.example.component.RequestIdFilter;
 import com.example.component.SessionIdFilter;
 import com.example.component.TimeLoggingFilter;
@@ -8,9 +10,14 @@ import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -22,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @Tag("integration")
 @ActiveProfiles(profiles = "profiling", inheritProfiles = false)
 @TestPropertySource(properties = "spring.jmx.enabled=true")
-class ProfilingProfileIntegrationTest extends BaseIntegrationTest {
+class ProfilingProfileIntegrationTest extends BaseRestIntegrationTest {
 
     private final ApplicationContext applicationContext;
     private final Environment environment;
@@ -30,11 +37,13 @@ class ProfilingProfileIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     ProfilingProfileIntegrationTest(
+            @LocalServerPort int localServerPort,
             ObjectMapper objectMapper,
+            RestTemplateBuilder restTemplateBuilder,
             ApplicationContext applicationContext,
             Environment environment,
             EntityManagerFactory entityManagerFactory) {
-        super(objectMapper);
+        super(localServerPort, objectMapper, restTemplateBuilder);
         this.applicationContext = applicationContext;
         this.environment = environment;
         this.entityManagerFactory = entityManagerFactory;
@@ -52,5 +61,26 @@ class ProfilingProfileIntegrationTest extends BaseIntegrationTest {
                 () -> assertThat(applicationContext.getBeansOfType(UserNameFilter.class)).hasSize(1),
                 () -> assertThat(applicationContext.getBeansOfType(TimeLoggingFilter.class)).hasSize(1)
         );
+    }
+
+    @Test
+    void profilingProfileExecutesRetainedFilters() {
+        Logger appLoggers = (Logger) LoggerFactory.getLogger("com.example");
+        Level originalLevel = appLoggers.getLevel();
+        try {
+            appLoggers.setLevel(Level.OFF);
+            ResponseEntity<String> responseEntity = this.restAnonymousTemplate.getForEntity("/", String.class);
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            appLoggers.setLevel(Level.DEBUG);
+            responseEntity = this.restAnonymousTemplate.getForEntity("/?profile=profiling", String.class);
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            appLoggers.setLevel(Level.INFO);
+            responseEntity = this.restAnonymousTemplate.getForEntity("/", String.class);
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        } finally {
+            appLoggers.setLevel(originalLevel);
+        }
     }
 }

--- a/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
+++ b/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
@@ -1,0 +1,56 @@
+package com.example.tests;
+
+import com.example.component.RequestIdFilter;
+import com.example.component.SessionIdFilter;
+import com.example.component.TimeLoggingFilter;
+import com.example.component.UserNameFilter;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.jmx.export.MBeanExporter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Tag("integration")
+@ActiveProfiles(profiles = "profiling", inheritProfiles = false)
+@TestPropertySource(properties = "spring.jmx.enabled=true")
+class ProfilingProfileIntegrationTest extends BaseIntegrationTest {
+
+    private final ApplicationContext applicationContext;
+    private final Environment environment;
+    private final EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    ProfilingProfileIntegrationTest(
+            ObjectMapper objectMapper,
+            ApplicationContext applicationContext,
+            Environment environment,
+            EntityManagerFactory entityManagerFactory) {
+        super(objectMapper);
+        this.applicationContext = applicationContext;
+        this.environment = environment;
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    @Test
+    void profilingProfileInstantiatesRetainedDiagnostics() {
+        assertAll(
+                () -> assertThat(environment.getActiveProfiles()).containsExactly("profiling"),
+                () -> assertThat(applicationContext.getBeansOfType(MBeanExporter.class)).hasSize(1),
+                () -> assertThat(entityManagerFactory.unwrap(SessionFactory.class).getStatistics().isStatisticsEnabled())
+                        .isTrue(),
+                () -> assertThat(applicationContext.getBeansOfType(RequestIdFilter.class)).hasSize(1),
+                () -> assertThat(applicationContext.getBeansOfType(SessionIdFilter.class)).hasSize(1),
+                () -> assertThat(applicationContext.getBeansOfType(UserNameFilter.class)).hasSize(1),
+                () -> assertThat(applicationContext.getBeansOfType(TimeLoggingFilter.class)).hasSize(1)
+        );
+    }
+}

--- a/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
+++ b/src/test/java/com/example/tests/ProfilingProfileIntegrationTest.java
@@ -10,6 +10,8 @@ import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.restclient.RestTemplateBuilder;
@@ -64,6 +66,7 @@ class ProfilingProfileIntegrationTest extends BaseRestIntegrationTest {
     }
 
     @Test
+    @ResourceLock(value = "logback:com.example", mode = ResourceAccessMode.READ_WRITE)
     void profilingProfileExecutesRetainedFilters() {
         Logger appLoggers = (Logger) LoggerFactory.getLogger("com.example");
         Level originalLevel = appLoggers.getLevel();

--- a/src/test/java/com/example/tests/RestIntegrationTest.java
+++ b/src/test/java/com/example/tests/RestIntegrationTest.java
@@ -2,13 +2,22 @@ package com.example.tests;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import com.example.component.RequestIdFilter;
+import com.example.component.SessionIdFilter;
+import com.example.component.TimeLoggingFilter;
+import com.example.component.UserNameFilter;
+import jakarta.persistence.EntityManagerFactory;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -18,6 +27,8 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -32,9 +43,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Slf4j
 @Tag("integration")
 @SuppressWarnings({
+        "PMD.ExcessiveImports",
         "PMD.TooManyStaticImports"
 })
 class RestIntegrationTest extends BaseRestIntegrationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private WebEndpointsSupplier webEndpointsSupplier;
 
     @Autowired
     RestIntegrationTest(
@@ -120,5 +144,30 @@ class RestIntegrationTest extends BaseRestIntegrationTest {
         assertThat(payload)
                 .containsKey("git")
                 .containsKey("build");
+    }
+
+    @Test
+    void testProfileUsesLeanRuntimeSemantics() {
+        Set<String> webEndpointIds = webEndpointsSupplier.getEndpoints().stream()
+                .map(endpoint -> endpoint.getEndpointId().toString())
+                .collect(Collectors.toSet());
+
+        assertAll(
+                () -> assertThat(environment.getActiveProfiles()).containsExactly("test"),
+                () -> assertThat(environment.getProperty("spring.jmx.enabled", Boolean.class)).isFalse(),
+                () -> assertThat(environment.getProperty(
+                        "spring.jpa.properties.hibernate.generate_statistics", Boolean.class)).isFalse(),
+                () -> assertThat(environment.getProperty("joinfaces.faces.project-stage")).isEqualTo("production"),
+                () -> assertThat(entityManagerFactory.unwrap(SessionFactory.class).getStatistics().isStatisticsEnabled())
+                        .isFalse(),
+                () -> assertThat(webEndpointIds).containsExactlyInAnyOrder("health", "info", "metrics", "prometheus"),
+                () -> assertThat(applicationContext.containsBean("beansEndpoint")).isFalse(),
+                () -> assertThat(applicationContext.containsBean("envEndpoint")).isFalse(),
+                () -> assertThat(applicationContext.containsBean("mbeanExporter")).isFalse(),
+                () -> assertThat(applicationContext.getBeansOfType(RequestIdFilter.class)).isEmpty(),
+                () -> assertThat(applicationContext.getBeansOfType(SessionIdFilter.class)).isEmpty(),
+                () -> assertThat(applicationContext.getBeansOfType(UserNameFilter.class)).isEmpty(),
+                () -> assertThat(applicationContext.getBeansOfType(TimeLoggingFilter.class)).isEmpty()
+        );
     }
 }

--- a/src/test/java/com/example/tests/RestIntegrationTest.java
+++ b/src/test/java/com/example/tests/RestIntegrationTest.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
@@ -78,6 +80,7 @@ class RestIntegrationTest extends BaseRestIntegrationTest {
     }
 
     @Test
+    @ResourceLock(value = "logback:com.example", mode = ResourceAccessMode.READ_WRITE)
     void homeLogging() {
         Logger appLoggers = (Logger) LoggerFactory.getLogger("com.example");
         appLoggers.setLevel(Level.OFF);

--- a/src/test/java/com/example/tests/RuntimeProfileConfigurationTest.java
+++ b/src/test/java/com/example/tests/RuntimeProfileConfigurationTest.java
@@ -1,0 +1,102 @@
+package com.example.tests;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.PropertySourcesPropertyResolver;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RuntimeProfileConfigurationTest {
+
+    private static final List<String> REQUIRED_ENDPOINTS = List.of("health", "info", "metrics", "prometheus");
+
+    @Test
+    void defaultProfileIsLean() throws IOException {
+        assertLean(resolver());
+    }
+
+    @Test
+    void deployedProfileIsLean() throws IOException {
+        assertLean(resolver("application-deployed.yaml"));
+    }
+
+    @Test
+    void testProfileIsLean() throws IOException {
+        assertLean(resolver("application-test.yaml"));
+    }
+
+    @Test
+    void localDevelopmentProfileRetainsDevelopmentDiagnostics() throws IOException {
+        PropertySourcesPropertyResolver properties = resolver("application-local-development.yaml");
+
+        assertThat(properties.getProperty("spring.jpa.properties.hibernate.generate_statistics", Boolean.class))
+                .isTrue();
+        assertThat(properties.getProperty("spring.jmx.enabled", Boolean.class)).isFalse();
+        assertThat(properties.getProperty("joinfaces.faces.project-stage")).isEqualTo("development");
+        assertThat(properties.getProperty("logging.level.web")).isEqualTo("DEBUG");
+        assertCustomFilters(properties, true);
+        assertRequiredEndpoints(properties);
+    }
+
+    @Test
+    void profilingProfileRetainsAllProfilingDiagnostics() throws IOException {
+        PropertySourcesPropertyResolver properties = resolver("application-profiling.yaml");
+
+        assertThat(properties.getProperty("spring.jpa.properties.hibernate.generate_statistics", Boolean.class))
+                .isTrue();
+        assertThat(properties.getProperty("spring.jmx.enabled", Boolean.class)).isTrue();
+        assertThat(properties.getProperty("joinfaces.faces.project-stage")).isEqualTo("development");
+        assertThat(properties.getProperty("logging.level.web")).isEqualTo("DEBUG");
+        assertThat(properties.getProperty("logging.level.com.sun.faces")).isEqualTo("trace");
+        assertCustomFilters(properties, true);
+        assertRequiredEndpoints(properties);
+    }
+
+    private void assertLean(PropertySourcesPropertyResolver properties) {
+        assertThat(properties.getProperty("spring.jpa.properties.hibernate.generate_statistics", Boolean.class))
+                .isFalse();
+        assertThat(properties.getProperty("spring.jmx.enabled", Boolean.class)).isFalse();
+        assertThat(properties.getProperty("joinfaces.faces.project-stage")).isEqualTo("production");
+        assertThat(properties.getProperty("logging.level.web")).isEqualTo("INFO");
+        assertCustomFilters(properties, false);
+        assertRequiredEndpoints(properties);
+    }
+
+    private void assertCustomFilters(PropertySourcesPropertyResolver properties, boolean enabled) {
+        for (String filter : List.of("time", "user", "session", "request")) {
+            assertThat(properties.getProperty("logging.custom." + filter + ".enable", Boolean.class))
+                    .as("logging.custom.%s.enable", filter)
+                    .isEqualTo(enabled);
+        }
+    }
+
+    private void assertRequiredEndpoints(PropertySourcesPropertyResolver properties) {
+        assertThat(properties.getProperty("management.endpoints.access.default")).isEqualTo("none");
+        assertThat(properties.getProperty("management.endpoints.web.exposure.include"))
+                .isEqualTo(String.join(",", REQUIRED_ENDPOINTS));
+        for (String endpoint : REQUIRED_ENDPOINTS) {
+            assertThat(properties.getProperty("management.endpoint." + endpoint + ".access"))
+                    .as("management.endpoint.%s.access", endpoint)
+                    .isEqualTo("read-only");
+        }
+    }
+
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    private PropertySourcesPropertyResolver resolver(String... overlays) throws IOException {
+        MutablePropertySources propertySources = new MutablePropertySources();
+        YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+        for (String overlay : overlays) {
+            List<PropertySource<?>> sources = loader.load(overlay, new ClassPathResource(overlay));
+            sources.forEach(propertySources::addLast);
+        }
+        loader.load("application.yaml", new ClassPathResource("application.yaml"))
+                .forEach(propertySources::addLast);
+        return new PropertySourcesPropertyResolver(propertySources);
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,10 +1,22 @@
 spring:
   devtools.restart.enabled: false
+  jmx.enabled: false
+  jpa.properties.hibernate.generate_statistics: false
+
+joinfaces:
+  faces:
+    project-stage: production
 
 logging:
   level:
+    web: INFO
     com:
       sun:
-        faces: trace
+        faces: info
     javax:
-      faces: trace
+      faces: info
+  custom:
+    time.enable: false
+    user.enable: false
+    session.enable: false
+    request.enable: false


### PR DESCRIPTION
Temporary hosted-CI probe for parent #1131 / profile child #1136.

This draft PR exists only to exercise the repository's `pull_request` workflow against current `master` for the already accepted exact performance head `2f79e1c570a6c0ca93537fe9296488be75b634be` (tree `36645bbd981c10156973fc860aab6fc94ec6d340`). It contains no new commit and must never be merged, marked ready, or given auto-merge.

The permanent final drafts remain #1148 (foundation/neutral) and stacked #1149 (performance); neither is changed by this probe. After all Actions and Codecov contexts are terminal and audited, this PR will be closed unmerged and its temporary branch deleted.

Visible task: https://chatgpt.com/codex/tasks/019f5fde-b285-7d22-a9fe-09a7a2e28285

Evidence: `C:\Users\kamki\.codex\campaigns\demo-spring-jsf-1131\evidence\hosted-ci-final-retry`
